### PR TITLE
Deprecation warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,6 @@ lazy val core = Project(
   base = file("core"),
   aggregate = Seq(sbtPlug)
 ).settings(assemblySettings ++ commonSettings ++ Seq(
-  scalacOptions += "-deprecation",
   name := "wartremover",
   scalaVersion := "2.11.1",
   addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.0" cross CrossVersion.full),

--- a/build.sbt
+++ b/build.sbt
@@ -66,6 +66,7 @@ lazy val core = Project(
   base = file("core"),
   aggregate = Seq(sbtPlug)
 ).settings(assemblySettings ++ commonSettings ++ Seq(
+  scalacOptions += "-deprecation",
   name := "wartremover",
   scalaVersion := "2.11.1",
   addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.0" cross CrossVersion.full),

--- a/core/src/main/scala/wartremover/Main.scala
+++ b/core/src/main/scala/wartremover/Main.scala
@@ -35,17 +35,17 @@ object Main {
     !global.reporter.hasErrors
   }
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val wartArgs = processArgs(args.toList, WartArgs.empty)
 
     if (wartArgs == WartArgs.empty) {
       System.err.println("usage: wartremover [-traverser qualifiedname ...] [file ...]")
       System.exit(1)
     } else if (wartArgs.traversers == WartArgs.empty.traversers) {
-      System.err.println("errer: no traverser rules were provided")
+      System.err.println("error: no traverser rules were provided")
       System.exit(1)
     } else if (wartArgs.names == WartArgs.empty.names) {
-      System.err.println("errer: no Scala files were provided")
+      System.err.println("error: no Scala files were provided")
       System.exit(1)
     } else if (!compile(wartArgs)) {
       System.exit(1)

--- a/core/src/main/scala/wartremover/Plugin.scala
+++ b/core/src/main/scala/wartremover/Plugin.scala
@@ -31,7 +31,7 @@ class Plugin(val global: Global) extends tools.nsc.plugins.Plugin {
   def filterOptions(prefix: String, options: List[String]) =
     options.map(prefixedOption(prefix)).flatten
 
-  override def processOptions(options: List[String], error: String => Unit) {
+  override def processOptions(options: List[String], error: String => Unit): Unit = {
     val classPathEntries = filterOptions("cp", options).map(new URL(_))
     val classLoader = new URLClassLoader(classPathEntries.toArray, getClass.getClassLoader)
     val mirror = reflect.runtime.universe.runtimeMirror(classLoader)
@@ -63,9 +63,9 @@ class Plugin(val global: Global) extends tools.nsc.plugins.Plugin {
           def wartUniverse(onlyWarn: Boolean) = new WartUniverse {
             val universe: global.type = global
             def error(pos: Position, message: String) =
-              if (onlyWarn) unit.warning(pos, message)
-              else unit.error(pos, message)
-            def warning(pos: Position, message: String) = unit.warning(pos, message)
+              if (onlyWarn) global.reporter.warning(pos, message)
+              else global.reporter.error(pos, message)
+            def warning(pos: Position, message: String) = global.reporter.warning(pos, message)
           }
 
           def go(ts: List[WartTraverser], onlyWarn: Boolean) =

--- a/core/src/main/scala/wartremover/WartTraverser.scala
+++ b/core/src/main/scala/wartremover/WartTraverser.scala
@@ -2,7 +2,7 @@ package org.brianmckenna.wartremover
 
 import tools.nsc.Global
 import reflect.api.Universe
-import reflect.macros.Context
+import reflect.macros.blackbox.Context
 
 trait WartTraverser {
   def apply(u: WartUniverse): u.Traverser
@@ -26,7 +26,7 @@ trait WartTraverser {
     import c.universe._
 
     val block = Block(annottees.map(_.tree).toList, Literal(Constant(())))
-    c.typeCheck(block)
+    c.typecheck(block)
 
     annottees.foreach { expr =>
       asMacro(c)(expr)
@@ -38,7 +38,7 @@ trait WartTraverser {
   def compose(o: WartTraverser): WartTraverser = new WartTraverser {
     def apply(u: WartUniverse): u.Traverser = {
       new u.Traverser {
-        override def traverse(tree: u.universe.Tree) {
+        override def traverse(tree: u.universe.Tree): Unit = {
           WartTraverser.this(u).traverse(tree)
           o(u).traverse(tree)
         }
@@ -65,6 +65,6 @@ trait WartUniverse {
   val universe: Universe
   type Traverser = universe.Traverser
   type TypeTag[T] = universe.TypeTag[T]
-  def error(pos: universe.Position, message: String)
-  def warning(pos: universe.Position, message: String)
+  def error(pos: universe.Position, message: String): Unit
+  def warning(pos: universe.Position, message: String): Unit
 }

--- a/core/src/main/scala/wartremover/WartTraverser.scala
+++ b/core/src/main/scala/wartremover/WartTraverser.scala
@@ -2,7 +2,7 @@ package org.brianmckenna.wartremover
 
 import tools.nsc.Global
 import reflect.api.Universe
-import reflect.macros.blackbox.Context
+import reflect.macros.Context
 
 trait WartTraverser {
   def apply(u: WartUniverse): u.Traverser
@@ -26,7 +26,7 @@ trait WartTraverser {
     import c.universe._
 
     val block = Block(annottees.map(_.tree).toList, Literal(Constant(())))
-    c.typecheck(block)
+    c.typeCheck(block)
 
     annottees.foreach { expr =>
       asMacro(c)(expr)

--- a/core/src/main/scala/wartremover/test/TestMacro.scala
+++ b/core/src/main/scala/wartremover/test/TestMacro.scala
@@ -2,7 +2,7 @@ package org.brianmckenna.wartremover
 package test
 
 import language.experimental.macros
-import reflect.macros.blackbox.Context
+import reflect.macros.Context
 
 object WartTestTraverser {
   case class Result(errors: List[String], warnings: List[String])
@@ -11,7 +11,7 @@ object WartTestTraverser {
   def applyImpl(c: Context)(t: c.Expr[WartTraverser])(a: c.Expr[Any]) = {
     import c.universe._
 
-    val traverser = c.eval[WartTraverser](c.Expr(c.untypecheck(t.tree.duplicate)))
+    val traverser = c.eval[WartTraverser](c.Expr(c.resetLocalAttrs(t.tree.duplicate)))
 
     var errors = collection.mutable.ListBuffer[String]()
     var warnings = collection.mutable.ListBuffer[String]()

--- a/core/src/main/scala/wartremover/test/TestMacro.scala
+++ b/core/src/main/scala/wartremover/test/TestMacro.scala
@@ -2,7 +2,7 @@ package org.brianmckenna.wartremover
 package test
 
 import language.experimental.macros
-import reflect.macros.Context
+import reflect.macros.blackbox.Context
 
 object WartTestTraverser {
   case class Result(errors: List[String], warnings: List[String])
@@ -11,7 +11,7 @@ object WartTestTraverser {
   def applyImpl(c: Context)(t: c.Expr[WartTraverser])(a: c.Expr[Any]) = {
     import c.universe._
 
-    val traverser = c.eval[WartTraverser](c.Expr(c.resetLocalAttrs(t.tree.duplicate)))
+    val traverser = c.eval[WartTraverser](c.Expr(c.untypecheck(t.tree.duplicate)))
 
     var errors = collection.mutable.ListBuffer[String]()
     var warnings = collection.mutable.ListBuffer[String]()

--- a/core/src/main/scala/wartremover/warts/Any2StringAdd.scala
+++ b/core/src/main/scala/wartremover/warts/Any2StringAdd.scala
@@ -5,8 +5,8 @@ object Any2StringAdd extends WartTraverser {
   def apply(u: WartUniverse): u.Traverser = {
     import u.universe._
 
-    val PredefName: TermName = TermName("Predef")
-    val Any2StringAddName: TermName = TermName("any2stringadd")
+    val PredefName: TermName = "Predef"
+    val Any2StringAddName: TermName = "any2stringadd"
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {

--- a/core/src/main/scala/wartremover/warts/Any2StringAdd.scala
+++ b/core/src/main/scala/wartremover/warts/Any2StringAdd.scala
@@ -5,10 +5,10 @@ object Any2StringAdd extends WartTraverser {
   def apply(u: WartUniverse): u.Traverser = {
     import u.universe._
 
-    val PredefName: TermName = "Predef"
-    val Any2StringAddName: TermName = "any2stringadd"
+    val PredefName: TermName = TermName("Predef")
+    val Any2StringAddName: TermName = TermName("any2stringadd")
     new u.Traverser {
-      override def traverse(tree: Tree) {
+      override def traverse(tree: Tree): Unit = {
         tree match {
           case Apply(Select(Select(_, PredefName), Any2StringAddName), _) =>
             u.error(tree.pos, "Scala inserted an any2stringadd call")

--- a/core/src/main/scala/wartremover/warts/AsInstanceOf.scala
+++ b/core/src/main/scala/wartremover/warts/AsInstanceOf.scala
@@ -4,8 +4,8 @@ package warts
 object AsInstanceOf extends WartTraverser {
   def apply(u: WartUniverse): u.Traverser = {
     import u.universe._
-    val EqualsName: TermName = TermName("equals")
-    val AsInstanceOfName: TermName = TermName("asInstanceOf")
+    val EqualsName: TermName = "equals"
+    val AsInstanceOfName: TermName = "asInstanceOf"
 
     val allowedCasts = List(
       "scala.tools.nsc.interpreter.IMain" // REPL needs this

--- a/core/src/main/scala/wartremover/warts/AsInstanceOf.scala
+++ b/core/src/main/scala/wartremover/warts/AsInstanceOf.scala
@@ -4,8 +4,8 @@ package warts
 object AsInstanceOf extends WartTraverser {
   def apply(u: WartUniverse): u.Traverser = {
     import u.universe._
-    val EqualsName: TermName = "equals"
-    val AsInstanceOfName: TermName = "asInstanceOf"
+    val EqualsName: TermName = TermName("equals")
+    val AsInstanceOfName: TermName = TermName("asInstanceOf")
 
     val allowedCasts = List(
       "scala.tools.nsc.interpreter.IMain" // REPL needs this
@@ -13,7 +13,7 @@ object AsInstanceOf extends WartTraverser {
       //   scala.ScalaReflectionException: object scala.tools.nsc.interpreter.IMain in compiler mirror not found.
 
     new u.Traverser {
-      override def traverse(tree: Tree) {
+      override def traverse(tree: Tree): Unit = {
         val synthetic = isSynthetic(u)(tree)
         tree match {
 

--- a/core/src/main/scala/wartremover/warts/DefaultArguments.scala
+++ b/core/src/main/scala/wartremover/warts/DefaultArguments.scala
@@ -10,7 +10,7 @@ object DefaultArguments extends WartTraverser {
       v.find(_.mods.hasFlag(DEFAULTPARAM)).isDefined
 
     new u.Traverser {
-      override def traverse(tree: Tree) {
+      override def traverse(tree: Tree): Unit = {
         tree match {
           case d@DefDef(_, _, _, vs, _, _) if !isSynthetic(u)(d) && vs.find(containsDef).isDefined =>
             u.error(tree.pos, "Function has default arguments")

--- a/core/src/main/scala/wartremover/warts/EitherProjectionPartial.scala
+++ b/core/src/main/scala/wartremover/warts/EitherProjectionPartial.scala
@@ -7,9 +7,9 @@ object EitherProjectionPartial extends WartTraverser {
 
     val leftProjectionSymbol = rootMirror.staticClass("scala.util.Either.LeftProjection")
     val rightProjectionSymbol = rootMirror.staticClass("scala.util.Either.RightProjection")
-    val GetName: TermName = "get"
+    val GetName: TermName = TermName("get")
     new u.Traverser {
-      override def traverse(tree: Tree) {
+      override def traverse(tree: Tree): Unit = {
         tree match {
           case Select(left, GetName) if left.tpe.baseType(leftProjectionSymbol) != NoType =>
             u.error(tree.pos, "LeftProjection#get is disabled - use LeftProjection#toOption instead")

--- a/core/src/main/scala/wartremover/warts/EitherProjectionPartial.scala
+++ b/core/src/main/scala/wartremover/warts/EitherProjectionPartial.scala
@@ -7,7 +7,7 @@ object EitherProjectionPartial extends WartTraverser {
 
     val leftProjectionSymbol = rootMirror.staticClass("scala.util.Either.LeftProjection")
     val rightProjectionSymbol = rootMirror.staticClass("scala.util.Either.RightProjection")
-    val GetName: TermName = TermName("get")
+    val GetName: TermName = "get"
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {

--- a/core/src/main/scala/wartremover/warts/ForbidInference.scala
+++ b/core/src/main/scala/wartremover/warts/ForbidInference.scala
@@ -5,10 +5,10 @@ trait ForbidInference[T] extends WartTraverser {
   def applyForbidden(u: WartUniverse)(implicit t: u.TypeTag[T]): u.Traverser = {
     import u.universe._
 
-    val CanEqualName: TermName = "canEqual"
-    val EqualsName: TermName = "equals"
-    val ProductElementName: TermName = "productElement"
-    val ProductIteratorName: TermName = "productIterator"
+    val CanEqualName: TermName = TermName("canEqual")
+    val EqualsName: TermName = TermName("equals")
+    val ProductElementName: TermName = TermName("productElement")
+    val ProductIteratorName: TermName = TermName("productIterator")
 
     val tSymbol = typeOf[T].typeSymbol
 
@@ -20,7 +20,7 @@ trait ForbidInference[T] extends WartTraverser {
     }
 
     new u.Traverser {
-      override def traverse(tree: Tree) {
+      override def traverse(tree: Tree): Unit = {
         val synthetic = isSynthetic(u)(tree)
         def error() = u.error(tree.pos, s"Inferred type containing ${tSymbol.name}")
 

--- a/core/src/main/scala/wartremover/warts/ForbidInference.scala
+++ b/core/src/main/scala/wartremover/warts/ForbidInference.scala
@@ -5,10 +5,10 @@ trait ForbidInference[T] extends WartTraverser {
   def applyForbidden(u: WartUniverse)(implicit t: u.TypeTag[T]): u.Traverser = {
     import u.universe._
 
-    val CanEqualName: TermName = TermName("canEqual")
-    val EqualsName: TermName = TermName("equals")
-    val ProductElementName: TermName = TermName("productElement")
-    val ProductIteratorName: TermName = TermName("productIterator")
+    val CanEqualName: TermName = "canEqual"
+    val EqualsName: TermName = "equals"
+    val ProductElementName: TermName = "productElement"
+    val ProductIteratorName: TermName = "productIterator"
 
     val tSymbol = typeOf[T].typeSymbol
 

--- a/core/src/main/scala/wartremover/warts/IsInstanceOf.scala
+++ b/core/src/main/scala/wartremover/warts/IsInstanceOf.scala
@@ -4,11 +4,11 @@ package warts
 object IsInstanceOf extends WartTraverser {
   def apply(u: WartUniverse): u.Traverser = {
     import u.universe._
-    val IsInstanceOfName: TermName = "isInstanceOf"
-    val CanEqualName: TermName = "canEqual"
-    val EqualsName: TermName = "equals"
+    val IsInstanceOfName: TermName = TermName("isInstanceOf")
+    val CanEqualName: TermName = TermName("canEqual")
+    val EqualsName: TermName = TermName("equals")
     new u.Traverser {
-      override def traverse(tree: Tree) {
+      override def traverse(tree: Tree): Unit = {
         val synthetic = isSynthetic(u)(tree)
         tree match {
 

--- a/core/src/main/scala/wartremover/warts/IsInstanceOf.scala
+++ b/core/src/main/scala/wartremover/warts/IsInstanceOf.scala
@@ -4,9 +4,9 @@ package warts
 object IsInstanceOf extends WartTraverser {
   def apply(u: WartUniverse): u.Traverser = {
     import u.universe._
-    val IsInstanceOfName: TermName = TermName("isInstanceOf")
-    val CanEqualName: TermName = TermName("canEqual")
-    val EqualsName: TermName = TermName("equals")
+    val IsInstanceOfName: TermName = "isInstanceOf"
+    val CanEqualName: TermName = "canEqual"
+    val EqualsName: TermName = "equals"
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         val synthetic = isSynthetic(u)(tree)

--- a/core/src/main/scala/wartremover/warts/JavaConversions.scala
+++ b/core/src/main/scala/wartremover/warts/JavaConversions.scala
@@ -8,7 +8,7 @@ object JavaConversions extends WartTraverser {
     val javaConversions = rootMirror.staticModule("scala.collection.JavaConversions")
 
     new u.Traverser {
-      override def traverse(tree: Tree) {
+      override def traverse(tree: Tree): Unit = {
         tree match {
           case Select(tpt, _) if tpt.tpe.contains(javaConversions) => {
             u.error(tree.pos, "scala.collection.JavaConversions is disabled - use scala.collection.JavaConverters instead")

--- a/core/src/main/scala/wartremover/warts/ListOps.scala
+++ b/core/src/main/scala/wartremover/warts/ListOps.scala
@@ -8,9 +8,9 @@ object ListOps extends WartTraverser {
       import u.universe._
 
       val listSymbol = rootMirror.staticClass("scala.collection.immutable.List")
-      val Name: TermName = name
+      val Name: TermName = TermName(name)
       new u.Traverser {
-        override def traverse(tree: Tree) {
+        override def traverse(tree: Tree): Unit = {
           tree match {
             case Select(left, Name) if left.tpe.baseType(listSymbol) != NoType ⇒
               u.error(tree.pos, error)

--- a/core/src/main/scala/wartremover/warts/ListOps.scala
+++ b/core/src/main/scala/wartremover/warts/ListOps.scala
@@ -8,7 +8,7 @@ object ListOps extends WartTraverser {
       import u.universe._
 
       val listSymbol = rootMirror.staticClass("scala.collection.immutable.List")
-      val Name: TermName = TermName(name)
+      val Name: TermName = name
       new u.Traverser {
         override def traverse(tree: Tree): Unit = {
           tree match {

--- a/core/src/main/scala/wartremover/warts/MutableDataStructures.scala
+++ b/core/src/main/scala/wartremover/warts/MutableDataStructures.scala
@@ -8,7 +8,7 @@ object MutableDataStructures extends WartTraverser {
     val mutablePackage = rootMirror.staticPackage("scala.collection.mutable")
 
     new u.Traverser {
-      override def traverse(tree: Tree) {
+      override def traverse(tree: Tree): Unit = {
         tree match {
           case Select(tpt, _) if tpt.tpe.contains(mutablePackage) && tpt.tpe.termSymbol.isPackage =>
             u.error(tree.pos, "scala.collection.mutable package is disabled")

--- a/core/src/main/scala/wartremover/warts/NoNeedForMonad.scala
+++ b/core/src/main/scala/wartremover/warts/NoNeedForMonad.scala
@@ -64,7 +64,7 @@ object NoNeedForMonad extends WartTraverser {
     }
 
     new u.Traverser {
-      override def traverse(tree: Tree) {
+      override def traverse(tree: Tree): Unit = {
         tree match {
           // Note: first two cases currently don't not work in 2.10: https://github.com/scalamacros/paradise/issues/38
           // Will propagate to matching desugared chain of maps/flatMaps.

--- a/core/src/main/scala/wartremover/warts/NonUnitStatements.scala
+++ b/core/src/main/scala/wartremover/warts/NonUnitStatements.scala
@@ -6,14 +6,14 @@ object NonUnitStatements extends WartTraverser {
     import u.universe._
     import scala.reflect.NameTransformer
 
-    val ReadName: TermName = "$read"
-    val IwName: TermName = "$iw"
-    val NodeBufferAddName: TermName = NameTransformer.encode("&+")
+    val ReadName: TermName = TermName("$read")
+    val IwName: TermName = TermName("$iw")
+    val NodeBufferAddName: TermName = TermName(NameTransformer.encode("&+"))
 
     def isIgnoredStatement(tree: Tree) = tree match {
       // Scala creates synthetic blocks with <init> calls on classes.
       // The calls return Object so we need to ignore them.
-      case Apply(Select(_, nme.CONSTRUCTOR), _) => true
+      case Apply(Select(_, termNames.CONSTRUCTOR), _) => true
       // scala.xml.NodeBuffer#&+ returns NodeBuffer instead of Unit, so
       // val x = <x>5</x> desugars to a non-Unit statement; ignore.
       case Apply(Select(qual, NodeBufferAddName), _)
@@ -23,7 +23,7 @@ object NonUnitStatements extends WartTraverser {
       case _ => false
     }
 
-    def checkUnitLike(statements: List[Tree]) {
+    def checkUnitLike(statements: List[Tree]): Unit = {
       statements.foreach { stat =>
         val unitLike = stat.isEmpty || stat.tpe == null || stat.tpe =:= typeOf[Unit] || stat.isDef || isIgnoredStatement(stat)
         if (!unitLike)
@@ -32,7 +32,7 @@ object NonUnitStatements extends WartTraverser {
     }
 
     new u.Traverser {
-      override def traverse(tree: Tree) {
+      override def traverse(tree: Tree): Unit = {
         tree match {
           case Block(statements, _) =>
             checkUnitLike(statements)

--- a/core/src/main/scala/wartremover/warts/NonUnitStatements.scala
+++ b/core/src/main/scala/wartremover/warts/NonUnitStatements.scala
@@ -6,14 +6,14 @@ object NonUnitStatements extends WartTraverser {
     import u.universe._
     import scala.reflect.NameTransformer
 
-    val ReadName: TermName = TermName("$read")
-    val IwName: TermName = TermName("$iw")
-    val NodeBufferAddName: TermName = TermName(NameTransformer.encode("&+"))
+    val ReadName: TermName = "$read"
+    val IwName: TermName = "$iw"
+    val NodeBufferAddName: TermName = NameTransformer.encode("&+")
 
     def isIgnoredStatement(tree: Tree) = tree match {
       // Scala creates synthetic blocks with <init> calls on classes.
       // The calls return Object so we need to ignore them.
-      case Apply(Select(_, termNames.CONSTRUCTOR), _) => true
+      case Apply(Select(_, nme.CONSTRUCTOR), _) => true
       // scala.xml.NodeBuffer#&+ returns NodeBuffer instead of Unit, so
       // val x = <x>5</x> desugars to a non-Unit statement; ignore.
       case Apply(Select(qual, NodeBufferAddName), _)

--- a/core/src/main/scala/wartremover/warts/Null.scala
+++ b/core/src/main/scala/wartremover/warts/Null.scala
@@ -5,15 +5,15 @@ object Null extends WartTraverser {
   def apply(u: WartUniverse): u.Traverser = {
     import u.universe._
 
-    val UnapplyName: TermName = "unapply"
-    val UnapplySeqName: TermName = "unapplySeq"
+    val UnapplyName: TermName = TermName("unapply")
+    val UnapplySeqName: TermName = TermName("unapplySeq")
     val xmlSymbols = List(
       "scala.xml.Elem", "scala.xml.NamespaceBinding"
     ) // cannot do `map rootMirror.staticClass` here because then:
       //   scala.ScalaReflectionException: object scala.xml.Elem in compiler mirror not found.
 
     new u.Traverser {
-      override def traverse(tree: Tree) {
+      override def traverse(tree: Tree): Unit = {
         val synthetic = isSynthetic(u)(tree)
         tree match {
           // Ignore xml literals

--- a/core/src/main/scala/wartremover/warts/Null.scala
+++ b/core/src/main/scala/wartremover/warts/Null.scala
@@ -5,8 +5,8 @@ object Null extends WartTraverser {
   def apply(u: WartUniverse): u.Traverser = {
     import u.universe._
 
-    val UnapplyName: TermName = TermName("unapply")
-    val UnapplySeqName: TermName = TermName("unapplySeq")
+    val UnapplyName: TermName = "unapply"
+    val UnapplySeqName: TermName = "unapplySeq"
     val xmlSymbols = List(
       "scala.xml.Elem", "scala.xml.NamespaceBinding"
     ) // cannot do `map rootMirror.staticClass` here because then:

--- a/core/src/main/scala/wartremover/warts/OptionPartial.scala
+++ b/core/src/main/scala/wartremover/warts/OptionPartial.scala
@@ -6,7 +6,7 @@ object OptionPartial extends WartTraverser {
     import u.universe._
 
     val optionSymbol = rootMirror.staticClass("scala.Option")
-    val GetName: TermName = TermName("get")
+    val GetName: TermName = "get"
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {

--- a/core/src/main/scala/wartremover/warts/OptionPartial.scala
+++ b/core/src/main/scala/wartremover/warts/OptionPartial.scala
@@ -6,9 +6,9 @@ object OptionPartial extends WartTraverser {
     import u.universe._
 
     val optionSymbol = rootMirror.staticClass("scala.Option")
-    val GetName: TermName = "get"
+    val GetName: TermName = TermName("get")
     new u.Traverser {
-      override def traverse(tree: Tree) {
+      override def traverse(tree: Tree): Unit = {
         tree match {
           case Select(left, GetName) if left.tpe.baseType(optionSymbol) != NoType =>
             u.error(tree.pos, "Option#get is disabled - use Option#fold instead")

--- a/core/src/main/scala/wartremover/warts/Return.scala
+++ b/core/src/main/scala/wartremover/warts/Return.scala
@@ -5,7 +5,7 @@ object Return extends WartTraverser {
   def apply(u: WartUniverse): u.Traverser = {
     import u.universe._
     new u.Traverser {
-      override def traverse(tree: Tree) {
+      override def traverse(tree: Tree): Unit = {
         tree match {
           case u.universe.Return(_) =>
             u.error(tree.pos, "return is disabled")

--- a/core/src/main/scala/wartremover/warts/TryPartial.scala
+++ b/core/src/main/scala/wartremover/warts/TryPartial.scala
@@ -6,9 +6,9 @@ object TryPartial extends WartTraverser {
     import u.universe._
 
     val optionSymbol = rootMirror.staticClass("scala.util.Try")
-    val GetName: TermName = "get"
+    val GetName: TermName = TermName("get")
     new u.Traverser {
-      override def traverse(tree: Tree) {
+      override def traverse(tree: Tree): Unit = {
         tree match {
           case Select(left, GetName) if left.tpe.baseType(optionSymbol) != NoType =>
             u.error(tree.pos, "Try#get is disabled")

--- a/core/src/main/scala/wartremover/warts/TryPartial.scala
+++ b/core/src/main/scala/wartremover/warts/TryPartial.scala
@@ -6,7 +6,7 @@ object TryPartial extends WartTraverser {
     import u.universe._
 
     val optionSymbol = rootMirror.staticClass("scala.util.Try")
-    val GetName: TermName = TermName("get")
+    val GetName: TermName = "get"
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {

--- a/core/src/main/scala/wartremover/warts/Var.scala
+++ b/core/src/main/scala/wartremover/warts/Var.scala
@@ -5,7 +5,7 @@ object Var extends WartTraverser {
   def apply(u: WartUniverse): u.Traverser = {
     import u.universe._
 
-    val HashCodeName: TermName = TermName("hashCode")
+    val HashCodeName: TermName = "hashCode"
 
     val allowedTypes = List(
       "scala.xml.MetaData", "scala.xml.NamespaceBinding", // XML literals output vars

--- a/core/src/main/scala/wartremover/warts/Var.scala
+++ b/core/src/main/scala/wartremover/warts/Var.scala
@@ -5,7 +5,7 @@ object Var extends WartTraverser {
   def apply(u: WartUniverse): u.Traverser = {
     import u.universe._
 
-    val HashCodeName: TermName = "hashCode"
+    val HashCodeName: TermName = TermName("hashCode")
 
     val allowedTypes = List(
       "scala.xml.MetaData", "scala.xml.NamespaceBinding", // XML literals output vars
@@ -14,7 +14,7 @@ object Var extends WartTraverser {
       //   scala.ScalaReflectionException: object scala.tools.nsc.interpreter.IMain in compiler mirror not found.
 
     new u.Traverser {
-      override def traverse(tree: Tree) {
+      override def traverse(tree: Tree): Unit = {
         val synthetic = isSynthetic(u)(tree)
         tree match {
           // Ignore case class's synthetic hashCode

--- a/core/src/test/scala/wartremover/safe/CaseClassTest.scala
+++ b/core/src/test/scala/wartremover/safe/CaseClassTest.scala
@@ -11,14 +11,14 @@ class CaseClassTest extends FunSuite {
       case class A(a: Int)
       case class B[X](a: X)
     }
-    expectResult(List.empty, "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
   test("vararg case classes still work") {
     val result = WartTestTraverser(Unsafe) {
       case class A(a: Int*)
     }
-    expectResult(List.empty, "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/core/src/test/scala/wartremover/safe/CompanionTest.scala
+++ b/core/src/test/scala/wartremover/safe/CompanionTest.scala
@@ -11,8 +11,8 @@ class CompanionTest extends FunSuite {
       case class Foo(n: Int)
       object Foo
     }
-    expectResult(List.empty, "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
   test("can use companion objects for type aliases") {
     val result = WartTestTraverser(Unsafe) {
@@ -20,7 +20,7 @@ class CompanionTest extends FunSuite {
       type T1 = String
       object T1 extends T[Unit]
     }
-    expectResult(List.empty, "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/core/src/test/scala/wartremover/safe/ExistentialTest.scala
+++ b/core/src/test/scala/wartremover/safe/ExistentialTest.scala
@@ -12,7 +12,7 @@ class ExistentialTest extends FunSuite {
       def values(names: Name[_]*) =
         names map { n => n.value }
     }
-    expectResult(List.empty, "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/core/src/test/scala/wartremover/safe/PartialFunctionTest.scala
+++ b/core/src/test/scala/wartremover/safe/PartialFunctionTest.scala
@@ -17,7 +17,7 @@ class PartialFunctionTest extends FunSuite {
         case 3 => 4
       }
     }
-    expectResult(List.empty, "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/core/src/test/scala/wartremover/safe/XmlLiteralTest.scala
+++ b/core/src/test/scala/wartremover/safe/XmlLiteralTest.scala
@@ -10,21 +10,21 @@ class XmlLiteralTest extends FunSuite {
     val result = WartTestTraverser(Unsafe) {
       val x = <foo />
     }
-    expectResult(List.empty, "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
   test("can use attributes in xml literals") {
     val result = WartTestTraverser(Unsafe) {
       <foo bar="baz" />
     }
-    expectResult(List.empty, "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
   test("can use xmlns attrib in XML literals") {
     val result = WartTestTraverser(Unsafe) {
       <x xmlns="y"/> // this one has special meaning
     }
-    expectResult(List.empty, "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/core/src/test/scala/wartremover/warts/Any2StringAddTest.scala
+++ b/core/src/test/scala/wartremover/warts/Any2StringAddTest.scala
@@ -10,7 +10,7 @@ class Any2StringAddTest extends FunSuite {
     val result = WartTestTraverser(Any2StringAdd) {
       {} + "lol"
     }
-    expectResult(List("Scala inserted an any2stringadd call"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("Scala inserted an any2stringadd call"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/core/src/test/scala/wartremover/warts/AnyTest.scala
+++ b/core/src/test/scala/wartremover/warts/AnyTest.scala
@@ -11,7 +11,7 @@ class AnyTest extends FunSuite {
       val x = readf1("{0}")
       x
     }
-    expectResult(List("Inferred type containing Any"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("Inferred type containing Any"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/core/src/test/scala/wartremover/warts/AsInstanceOfTest.scala
+++ b/core/src/test/scala/wartremover/warts/AsInstanceOfTest.scala
@@ -10,7 +10,7 @@ class AsInstanceOfTest extends FunSuite {
     val result = WartTestTraverser(AsInstanceOf) {
       "abc".asInstanceOf[String]
     }
-    expectResult(List("asInstanceOf is disabled"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("asInstanceOf is disabled"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/core/src/test/scala/wartremover/warts/DefaultArgumentsTest.scala
+++ b/core/src/test/scala/wartremover/warts/DefaultArgumentsTest.scala
@@ -10,7 +10,7 @@ class DefaultArgumentsTest extends FunSuite {
     val result = WartTestTraverser(DefaultArguments) {
       def x(y: Int = 4) = y
     }
-    expectResult(List("Function has default arguments"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("Function has default arguments"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/core/src/test/scala/wartremover/warts/EitherProjectionPartialTest.scala
+++ b/core/src/test/scala/wartremover/warts/EitherProjectionPartialTest.scala
@@ -10,28 +10,28 @@ class EitherProjectionPartialTest extends FunSuite {
     val result = WartTestTraverser(EitherProjectionPartial) {
       println(Left(1).left.get)
     }
-    expectResult(List("LeftProjection#get is disabled - use LeftProjection#toOption instead"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("LeftProjection#get is disabled - use LeftProjection#toOption instead"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
   test("can't use LeftProjection#get on Right") {
     val result = WartTestTraverser(EitherProjectionPartial) {
       println(Right(1).left.get)
     }
-    expectResult(List("LeftProjection#get is disabled - use LeftProjection#toOption instead"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("LeftProjection#get is disabled - use LeftProjection#toOption instead"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
   test("can't use RightProjection#get on Left") {
     val result = WartTestTraverser(EitherProjectionPartial) {
       println(Left(1).right.get)
     }
-    expectResult(List("RightProjection#get is disabled - use RightProjection#toOption instead"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("RightProjection#get is disabled - use RightProjection#toOption instead"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
   test("can't use RightProjection#get on Right") {
     val result = WartTestTraverser(EitherProjectionPartial) {
       println(Right(1).right.get)
     }
-    expectResult(List("RightProjection#get is disabled - use RightProjection#toOption instead"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("RightProjection#get is disabled - use RightProjection#toOption instead"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/core/src/test/scala/wartremover/warts/IsInstanceOfTest.scala
+++ b/core/src/test/scala/wartremover/warts/IsInstanceOfTest.scala
@@ -10,7 +10,7 @@ class IsInstanceOfTest extends FunSuite {
     val result = WartTestTraverser(IsInstanceOf) {
       "abc".isInstanceOf[String]
     }
-    expectResult(List("isInstanceOf is disabled"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("isInstanceOf is disabled"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/core/src/test/scala/wartremover/warts/JavaConversionsTest.scala
+++ b/core/src/test/scala/wartremover/warts/JavaConversionsTest.scala
@@ -11,8 +11,8 @@ class JavaConversionsTest extends FunSuite {
       def ff[A](it: Iterable[A]) = collection.JavaConversions.asJavaCollection(it)
       
     }
-    expectResult(List("scala.collection.JavaConversions is disabled - use scala.collection.JavaConverters instead"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("scala.collection.JavaConversions is disabled - use scala.collection.JavaConverters instead"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
    
   }  
   test("disable scala.collection.JavaConversions when referenced in an import") {
@@ -21,8 +21,8 @@ class JavaConversionsTest extends FunSuite {
       val x: java.util.List[Int]= new java.util.ArrayList[Int]
       val y: Seq[Int] = x
     }
-    expectResult(List("scala.collection.JavaConversions is disabled - use scala.collection.JavaConverters instead"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("scala.collection.JavaConversions is disabled - use scala.collection.JavaConverters instead"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
    
   } 
 }

--- a/core/src/test/scala/wartremover/warts/ListTest.scala
+++ b/core/src/test/scala/wartremover/warts/ListTest.scala
@@ -10,24 +10,24 @@ class ListTest extends FunSuite {
     val result = WartTestTraverser(ListOps) {
       println(List(1).head)
     }
-    expectResult(List("List#head is disabled - use List#headOption instead"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("List#head is disabled - use List#headOption instead"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
 
   test("can't use List#tail on List") {
     val result = WartTestTraverser(ListOps) {
       println(List().tail)
     }
-    expectResult(List("List#tail is disabled - use List#drop(1) instead"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("List#tail is disabled - use List#drop(1) instead"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
 
   test("can't use List#last on List") {
     val result = WartTestTraverser(ListOps) {
       println(List().last)
     }
-    expectResult(List("List#last is disabled - use List#lastOption instead"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("List#last is disabled - use List#lastOption instead"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
 
 }

--- a/core/src/test/scala/wartremover/warts/MutableDataStructuresTest.scala
+++ b/core/src/test/scala/wartremover/warts/MutableDataStructuresTest.scala
@@ -10,14 +10,14 @@ class MutableDataStructuresTest extends FunSuite {
     val result = WartTestTraverser(MutableDataStructures) {
       var x = scala.collection.mutable.HashMap("key" -> "value")
     }
-    expectResult(List("scala.collection.mutable package is disabled"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("scala.collection.mutable package is disabled"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
   test("ignore immutable collections") {
     val result = WartTestTraverser(MutableDataStructures) {
       var x = Map("key" -> "value")
     }
-    expectResult(List.empty, "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/core/src/test/scala/wartremover/warts/NoNeedForMonadTest.scala
+++ b/core/src/test/scala/wartremover/warts/NoNeedForMonadTest.scala
@@ -34,13 +34,13 @@ class NoNeedForMonadTest extends FunSuite {
       Option(3).flatMap { case t => Some(t) }
     }
 
-    expectResult(List.empty, "result.errors")(withWarnings.errors)
-    expectResult(List(NoNeedForMonad.message, NoNeedForMonad.message), "result.warnings")(withWarnings.warnings)
+    assertResult(List.empty, "result.errors")(withWarnings.errors)
+    assertResult(List(NoNeedForMonad.message, NoNeedForMonad.message), "result.warnings")(withWarnings.warnings)
 
-    expectResult(List.empty, "result.errors")(noWarnings.errors)
-    expectResult(List.empty, "result.warnings")(noWarnings.warnings)
+    assertResult(List.empty, "result.errors")(noWarnings.errors)
+    assertResult(List.empty, "result.warnings")(noWarnings.warnings)
 
-    expectResult(List.empty, "result.errors")(test.errors)
-    expectResult(List(NoNeedForMonad.message), "result.warnings")(test.warnings)
+    assertResult(List.empty, "result.errors")(test.errors)
+    assertResult(List(NoNeedForMonad.message), "result.warnings")(test.warnings)
   }
 }

--- a/core/src/test/scala/wartremover/warts/NonUnitStatementsTest.scala
+++ b/core/src/test/scala/wartremover/warts/NonUnitStatementsTest.scala
@@ -11,15 +11,15 @@ class NonUnitStatementsTest extends FunSuite {
       1
       2
     }
-    expectResult(List("Statements must return Unit"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("Statements must return Unit"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
   test("XML literals don't fail") {
     val result = WartTestTraverser(NonUnitStatements) {
       val a = 13
       <x>{a}</x>
     }
-    expectResult(List.empty, "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/core/src/test/scala/wartremover/warts/NothingTest.scala
+++ b/core/src/test/scala/wartremover/warts/NothingTest.scala
@@ -11,7 +11,7 @@ class NothingTest extends FunSuite {
       val x = ???
       x
     }
-    expectResult(List("Inferred type containing Nothing"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("Inferred type containing Nothing"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/core/src/test/scala/wartremover/warts/NullTest.scala
+++ b/core/src/test/scala/wartremover/warts/NullTest.scala
@@ -10,22 +10,22 @@ class NullTest extends FunSuite {
     val result = WartTestTraverser(Null) {
       println(null)
     }
-    expectResult(List("null is disabled"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("null is disabled"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
   test("can't use null in patterns") {
     val result = WartTestTraverser(Null) {
       val (a, b) = (1, null)
       println(a)
     }
-    expectResult(List("null is disabled"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("null is disabled"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
   test("can't use null inside of Map#partition") {
     val result = WartTestTraverser(Null) {
       Map(1 -> "one", 2 -> "two").partition { case (k, v) => null.asInstanceOf[Boolean] }
     }
-    expectResult(List("null is disabled"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("null is disabled"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/core/src/test/scala/wartremover/warts/OptionPartialTest.scala
+++ b/core/src/test/scala/wartremover/warts/OptionPartialTest.scala
@@ -10,22 +10,22 @@ class OptionPartialTest extends FunSuite {
     val result = WartTestTraverser(OptionPartial) {
       println(Some(1).get)
     }
-    expectResult(List("Option#get is disabled - use Option#fold instead"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("Option#get is disabled - use Option#fold instead"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
   test("can't use Option#get on None") {
     val result = WartTestTraverser(OptionPartial) {
       println(None.get)
     }
-    expectResult(List("Option#get is disabled - use Option#fold instead"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("Option#get is disabled - use Option#fold instead"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
   test("doesn't detect other `get` methods") {
     val result = WartTestTraverser(OptionPartial) {
       case class A(get: Int)
       println(A(1).get)
     }
-    expectResult(List.empty, "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/core/src/test/scala/wartremover/warts/ProductTest.scala
+++ b/core/src/test/scala/wartremover/warts/ProductTest.scala
@@ -10,7 +10,7 @@ class ProductTest extends FunSuite {
     val result = WartTestTraverser(Product) {
       List((1, 2, 3), (1, 2))
     }
-    expectResult(List("Inferred type containing Product"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("Inferred type containing Product"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/core/src/test/scala/wartremover/warts/ReturnTest.scala
+++ b/core/src/test/scala/wartremover/warts/ReturnTest.scala
@@ -10,14 +10,14 @@ class ReturnTest extends FunSuite {
     val result = WartTestTraverser(Return) {
       def foo(n:Int): Int = return n + 1
     }
-    expectResult(List("return is disabled"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("return is disabled"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
   test("nonlocal return is disabled") {
     val result = WartTestTraverser(Return) {
       def foo(ns: List[Int]): Any = ns.map(n => return n + 1)
     }
-    expectResult(List("return is disabled"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("return is disabled"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/core/src/test/scala/wartremover/warts/SerializableTest.scala
+++ b/core/src/test/scala/wartremover/warts/SerializableTest.scala
@@ -10,7 +10,7 @@ class SerializableTest extends FunSuite {
     val result = WartTestTraverser(Serializable) {
       List((1, 2, 3), (1, 2))
     }
-    expectResult(List("Inferred type containing Serializable"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("Inferred type containing Serializable"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/core/src/test/scala/wartremover/warts/TryPartialTest.scala
+++ b/core/src/test/scala/wartremover/warts/TryPartialTest.scala
@@ -10,22 +10,22 @@ class TryPartialTest extends FunSuite {
     val result = WartTestTraverser(TryPartial) {
       println(Success(1).get)
     }
-    expectResult(List("Try#get is disabled"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("Try#get is disabled"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
   test("can't use Try#get on Failure") {
     val result = WartTestTraverser(TryPartial) {
       println(Failure(new Error).get)
     }
-    expectResult(List("Try#get is disabled"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("Try#get is disabled"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
   test("doesn't detect other `get` methods") {
     val result = WartTestTraverser(TryPartial) {
       case class A(get: Int)
       println(A(1).get)
     }
-    expectResult(List.empty, "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/core/src/test/scala/wartremover/warts/UnsafeTest.scala
+++ b/core/src/test/scala/wartremover/warts/UnsafeTest.scala
@@ -17,7 +17,7 @@ class UnsafeTest extends FunSuite {
       println(Right(42).right.get)
       println(null)
     }
-    expectResult(
+    assertResult(
       Set("Inferred type containing Any",
            "Inferred type containing Any",
            "Scala inserted an any2stringadd call",
@@ -29,6 +29,6 @@ class UnsafeTest extends FunSuite {
            "null is disabled",
            "Option#get is disabled - use Option#fold instead",
            "var is disabled"), "result.errors")(result.errors.toSet)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/core/src/test/scala/wartremover/warts/VarTest.scala
+++ b/core/src/test/scala/wartremover/warts/VarTest.scala
@@ -11,7 +11,7 @@ class VarTest extends FunSuite {
       var x = 10
       x
     }
-    expectResult(List("var is disabled"), "result.errors")(result.errors)
-    expectResult(List.empty, "result.warnings")(result.warnings)
+    assertResult(List("var is disabled"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
   }
 }


### PR DESCRIPTION
compiler: scalac 2.11.4
flags: -Xlint:_ -Xfuture -Xlog-free-terms -deprecation -optimize

fix:
Procedure syntax is deprecated.
Context in package macros is deprecated: Use blackbox.Context
method typeCheck in trait Typers is deprecated: Use `c.typecheck` instead
stringToTermName is deprecated, use explicit TermName
nme in StandardNames is deprecated, use TermNames instead
method error in class CompilationUnit is deprecated: Call global.reporter.error
method warning in class CompilationUnit is deprecated: Call global.reporter.warning
resetLocalAttrs in trait Typers is deprecated: Use c.untypecheck
expectResult in trait Assertions is deprecated: use assertResult
spelling "error" :)

notes:
All unit tests pass
Build successful via sbt and direct compile.
Command-line usage confirmed.
build.sbt is updated with `-deprecated` on by default
one warning remains in NonUnitStatementsTest.scala, involving macro syntax.

also:
I'm new to github. Comments welcome, and thanks for maintaining this awesome tool.