### PR TITLE
Fix #103: Add warts.Throw

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,12 @@ always incorrect. Explicit type arguments should be used instead.
 // Won't compile: Inferred type containing Serializable
 val any = List((1, 2, 3), (1, 2))
 ```
+
+### Throw
+
+`throw` implies partiality referential transparency. Encode exceptions/errors as
+return values instead using `Either` or `Try`. 
+
 ### Unsafe
 
 Checks for the following warts:
@@ -266,6 +272,7 @@ Checks for the following warts:
 * Product
 * Return
 * Serializable
+* Throw
 * Var
 * ListOps
 

--- a/core/src/main/scala/wartremover/warts/Throw.scala
+++ b/core/src/main/scala/wartremover/warts/Throw.scala
@@ -1,0 +1,21 @@
+package org.brianmckenna.wartremover
+package warts
+
+object Throw extends WartTraverser {
+  def apply(u: WartUniverse): u.Traverser = {
+    import u.universe._
+    val ProductElementName: TermName = "productElement"
+    new u.Traverser {
+      override def traverse(tree: Tree) {
+        tree match {
+          case dd@DefDef(_, ProductElementName , _, _, _, _) if isSynthetic(u)(dd) =>
+          case u.universe.Throw(_) =>
+            u.error(tree.pos, "throw is disabled")
+            super.traverse(tree)
+          case _ =>
+            super.traverse(tree)
+        }
+      }
+    }
+  }
+}

--- a/core/src/main/scala/wartremover/warts/Unsafe.scala
+++ b/core/src/main/scala/wartremover/warts/Unsafe.scala
@@ -15,6 +15,7 @@ object Unsafe extends WartTraverser {
     Product,
     Return,
     Serializable,
+    Throw,
     TryPartial,
     Var,
     ListOps

--- a/core/src/test/scala/wartremover/warts/ThrowTest.scala
+++ b/core/src/test/scala/wartremover/warts/ThrowTest.scala
@@ -1,0 +1,24 @@
+package org.brianmckenna.wartremover
+package test
+
+import org.scalatest.FunSuite
+
+import org.brianmckenna.wartremover.warts.Throw
+
+class ThrowTest extends FunSuite {
+  test("throw is disabled") {
+    val result = WartTestTraverser(Throw) {
+      def foo(n: Int): Int = throw new IllegalArgumentException("bar")
+    }
+    assertResult(List("throw is disabled"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+
+  test("throw is allowed in synthetic Product.productElement") {
+    val result = WartTestTraverser(Throw) {
+      case class Foo(i: Int)
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+}


### PR DESCRIPTION
This PR fixes #103. Please note that we have to filter out the cases when `throw` statement is generated for cases classes (i.e., for method `productElement`). It usually looks as follows:

```scala
case class Foo(x: String) {
  def productElement(n: Int): Any = n match {
    case 0 => x
    case _ => throw new IndexOutOfBoundsException(n.toString)
  }
}
```