### PR TITLE
Ignore arguments that don't match function literal or eta-expanded function in NoNeedForMonad

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ lazy val root = Project(
   aggregate = Seq(core)
 ).settings(releaseSettings ++ commonSettings ++ Seq(
   publishArtifact := false,
-  crossScalaVersions := Seq("2.11.1", "2.10.4"),
+  crossScalaVersions := Seq("2.11.5", "2.10.4"),
   crossVersion := CrossVersion.binary,
   releaseProcess := Seq[ReleaseStep](
     checkSnapshotDependencies,
@@ -68,18 +68,18 @@ lazy val core = Project(
 ).settings(assemblySettings ++ commonSettings ++ Seq(
   name := "wartremover",
   scalaVersion := "2.11.1",
-  addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.0" cross CrossVersion.full),
+  addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full),
   libraryDependencies := {
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, 10)) =>
-        libraryDependencies.value :+ ("org.scalamacros" %% "quasiquotes" % "2.0.0")
+        libraryDependencies.value :+ ("org.scalamacros" %% "quasiquotes" % "2.0.1")
       case _ =>
         libraryDependencies.value
     }
   },
   libraryDependencies ++= Seq(
     "org.scala-lang" % "scala-compiler" % scalaVersion.value,
-    "org.scalatest" %% "scalatest" % "2.1.3" % "test"
+    "org.scalatest" %% "scalatest" % "2.2.1" % "test"
   ),
   // a hack (?) to make `compile` and `+compile` tasks etc. behave sanely
   aggregate := CrossVersion.partialVersion((scalaVersion in Global).value) != Some((2, 11))

--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ lazy val root = Project(
   aggregate = Seq(core)
 ).settings(releaseSettings ++ commonSettings ++ Seq(
   publishArtifact := false,
-  crossScalaVersions := Seq("2.11.5", "2.10.4"),
+  crossScalaVersions := Seq("2.11.6", "2.10.5"),
   crossVersion := CrossVersion.binary,
   releaseProcess := Seq[ReleaseStep](
     checkSnapshotDependencies,
@@ -67,7 +67,7 @@ lazy val core = Project(
   aggregate = Seq(sbtPlug)
 ).settings(assemblySettings ++ commonSettings ++ Seq(
   name := "wartremover",
-  scalaVersion := "2.11.1",
+  scalaVersion := "2.11.6",
   addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full),
   libraryDependencies := {
     CrossVersion.partialVersion(scalaVersion.value) match {

--- a/core/src/main/scala/wartremover/warts/NoNeedForMonad.scala
+++ b/core/src/main/scala/wartremover/warts/NoNeedForMonad.scala
@@ -48,14 +48,13 @@ object NoNeedForMonad extends WartTraverser {
       }
 
       if(!asFunc.isEmpty) {
-        val yields = asFunc.last._2
-
+        val (_, yields) = asFunc.last
         val treesToCheck = asFunc.reverse.tail.toMap
         val results = treesToCheck.flatMap { case (args, body) =>
           args.map { arg =>
             // Argument should occur in the body of the function the number of times
             // it occurs in the yield statement
-            // (i.e. only occurances are in the yield statement are allowed).
+            // (i.e. only occurances in the yield statement are allowed).
             val countInYield = yields.filter(_ equalsStructure arg).size
             body.filter(_ equalsStructure arg).size == countInYield
           }

--- a/core/src/main/scala/wartremover/warts/NoNeedForMonad.scala
+++ b/core/src/main/scala/wartremover/warts/NoNeedForMonad.scala
@@ -54,7 +54,7 @@ object NoNeedForMonad extends WartTraverser {
           args.map { arg =>
             // Argument should occur in the body of the function the number of times
             // it occurs in the yield statement
-            // (i.e. only occurances in the yield statement are allowed).
+            // (i.e. only occurrences in the yield statement are allowed).
             val countInYield = yields.filter(_ equalsStructure arg).size
             body.filter(_ equalsStructure arg).size == countInYield
           }

--- a/core/src/test/scala/wartremover/warts/NoNeedForMonadTest.scala
+++ b/core/src/test/scala/wartremover/warts/NoNeedForMonadTest.scala
@@ -9,8 +9,8 @@ class NoNeedForMonadTest extends FunSuite {
   test("Report cases where Applicative is enough") {
     val withWarnings = WartTestTraverser(NoNeedForMonad) {
       for {
-        x <- List(1,2,3)
-        y <- List(2,3,4)
+        x <- List(1, 2, 3)
+        y <- List(2, 3, 4)
       } yield x * y
 
       Option(1).flatMap(i => Option(2).map(j => i + j))
@@ -38,8 +38,18 @@ class NoNeedForMonadTest extends FunSuite {
       object test extends Function1[Int, Option[Int]] {
         def apply(i: Int) = Option(i + 2)
       }
+      object test2 {
+        def apply(i: Int) = Option(i + 4)
+      }
 
-      Option(1) flatMap test
+      for {
+        x <- Option(1)
+        res <- test(x)
+      } yield res
+      for {
+        x <- Option(2)
+        res <- test2(x)
+      } yield res
     }
 
     expectResult(List.empty, "result.errors")(withWarnings.errors)

--- a/core/src/test/scala/wartremover/warts/NoNeedForMonadTest.scala
+++ b/core/src/test/scala/wartremover/warts/NoNeedForMonadTest.scala
@@ -34,6 +34,14 @@ class NoNeedForMonadTest extends FunSuite {
       Option(3).flatMap { case t => Some(t) }
     }
 
+    val extendsFunction = WartTestTraverser(NoNeedForMonad) {
+      object test extends Function1[Int, Option[Int]] {
+        def apply(i: Int) = Option(i + 2)
+      }
+
+      Option(1) flatMap test
+    }
+
     expectResult(List.empty, "result.errors")(withWarnings.errors)
     expectResult(List(NoNeedForMonad.message, NoNeedForMonad.message), "result.warnings")(withWarnings.warnings)
 
@@ -42,5 +50,8 @@ class NoNeedForMonadTest extends FunSuite {
 
     expectResult(List.empty, "result.errors")(test.errors)
     expectResult(List(NoNeedForMonad.message), "result.warnings")(test.warnings)
+
+    expectResult(List.empty, "result.errors")(extendsFunction.errors)
+    expectResult(List.empty, "result.errors")(extendsFunction.warnings)
   }
 }

--- a/core/src/test/scala/wartremover/warts/NoNeedForMonadTest.scala
+++ b/core/src/test/scala/wartremover/warts/NoNeedForMonadTest.scala
@@ -24,7 +24,15 @@ class NoNeedForMonadTest extends FunSuite {
       Option(1).flatMap(i => Option(i + 1).map(j => i + j))
     }
 
-    val test = WartTestTraverser(NoNeedForMonad) {
+    expectResult(List.empty, "result.errors")(withWarnings.errors)
+    expectResult(List(NoNeedForMonad.message, NoNeedForMonad.message), "result.warnings")(withWarnings.warnings)
+
+    expectResult(List.empty, "result.errors")(noWarnings.errors)
+    expectResult(List.empty, "result.warnings")(noWarnings.warnings)
+  }
+
+  test("Work properly with function literals, eta-expanded functions, objects with apply methods") {
+    val etaExpanded = WartTestTraverser(NoNeedForMonad) {
       def fun(in: Int) = 14
       val xs = for {
         y <- Nil
@@ -52,14 +60,9 @@ class NoNeedForMonadTest extends FunSuite {
       } yield res
     }
 
-    expectResult(List.empty, "result.errors")(withWarnings.errors)
-    expectResult(List(NoNeedForMonad.message, NoNeedForMonad.message), "result.warnings")(withWarnings.warnings)
 
-    expectResult(List.empty, "result.errors")(noWarnings.errors)
-    expectResult(List.empty, "result.warnings")(noWarnings.warnings)
-
-    expectResult(List.empty, "result.errors")(test.errors)
-    expectResult(List(NoNeedForMonad.message), "result.warnings")(test.warnings)
+    expectResult(List.empty, "result.errors")(etaExpanded.errors)
+    expectResult(List(NoNeedForMonad.message), "result.warnings")(etaExpanded.warnings)
 
     expectResult(List.empty, "result.errors")(extendsFunction.errors)
     expectResult(List.empty, "result.errors")(extendsFunction.warnings)


### PR DESCRIPTION
This is a quick and dirty fix for https://github.com/puffnfresh/wartremover/issues/142. The third case that @travisbrown mentioned is (I guess) something that extends `Function1`. This PR just ignores arguments like that (and all the other arguments) because the tree we're getting back looks like this `Ident(TermName("test"))`, and I'm not sure how to get my hands on `test.apply` tree here.

/cc @puffnfresh @vkostyukov