### PR TITLE
Warts should obey the `SuppressWarnings` annotation and not create errors or warnings for annotated code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,10 @@ To exclude a file from all checks:
 wartremoverExcluded += baseDirectory.value / "src" / "main" / "scala" / "SomeFile.scala"
 ```
 
-To exclude a specific piece of code from one or more checks use the `ignoreWarts` annotation:
+To exclude a specific piece of code from one or more checks use the `SuppressWarnings` annotation:
 ```scala
-@ignoreWarts("org.brianmckenna.wartremover.warts.Var", "org.brianmckenna.wartremover.warts.Null")
+@SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Var", "org.brianmckenna.wartremover.warts.Null"))
 var foo = null
-```
-This will require you to add wartremover as a library dependency:
-```scala
-libraryDependencies += "org.brianmckenna" %% "wartremover" % "0.13-SNAPSHOT"
 ```
 
 Finally, if you want to add your custom `WartTraverser`, provide its classpath first:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ To exclude a file from all checks:
 wartremoverExcluded += baseDirectory.value / "src" / "main" / "scala" / "SomeFile.scala"
 ```
 
+To exclude a specific piece of code from one or more checks use the `ignoreWarts` annotation:
+```scala
+@ignoreWarts("org.brianmckenna.wartremover.warts.Var", "org.brianmckenna.wartremover.warts.Null")
+var foo = null
+```
+This will require you to add wartremover as a library dependency:
+```scala
+libraryDependencies += "org.brianmckenna" %% "wartremover" % "0.13-SNAPSHOT"
+```
+
 Finally, if you want to add your custom `WartTraverser`, provide its classpath first:
 
 ```scala

--- a/core/src/main/scala/wartremover/WartTraverser.scala
+++ b/core/src/main/scala/wartremover/WartTraverser.scala
@@ -60,9 +60,11 @@ trait WartTraverser {
 
   def isWartAnnotation(u: WartUniverse)(a : u.universe.Annotation) : Boolean = {
     import u.universe._
-    a.tpe <:< typeTag[ignoreWarts].tpe &&
-      a.scalaArgs.exists {
-        case Literal(Constant(arg)) => arg == className
+    a.tpe <:< typeTag[java.lang.SuppressWarnings].tpe &&
+      a.javaArgs.exists {
+        case Tuple2(_, ArrayArgument(args)) => args.exists {
+          case LiteralArgument(Constant(arg)) => arg == className
+        }
         case _ => false
       }
   }

--- a/core/src/main/scala/wartremover/WartTraverser.scala
+++ b/core/src/main/scala/wartremover/WartTraverser.scala
@@ -3,9 +3,12 @@ package org.brianmckenna.wartremover
 import tools.nsc.Global
 import reflect.api.Universe
 import reflect.macros.Context
+import scala.util.Try
 
 trait WartTraverser {
   def apply(u: WartUniverse): u.Traverser
+
+  lazy val className = this.getClass.getName.stripSuffix("$")
 
   def asMacro(c: Context)(expr: c.Expr[Any]): c.Expr[Any] = {
     import c.universe._
@@ -54,6 +57,18 @@ trait WartTraverser {
 
   def wasInferred(u: WartUniverse)(t: u.universe.TypeTree): Boolean =
     t.original == null
+
+  def isWartAnnotation(u: WartUniverse)(a : u.universe.Annotation) : Boolean = {
+    import u.universe._
+    a.tpe <:< typeTag[ignoreWarts].tpe &&
+      a.scalaArgs.exists {
+        case Literal(Constant(arg)) => arg == className
+        case _ => false
+      }
+  }
+
+	def hasWartAnnotation(u: WartUniverse)(t: u.universe.Tree) =
+		Try(t.symbol.annotations.exists(isWartAnnotation(u))).getOrElse(false)
 }
 
 object WartTraverser {

--- a/core/src/main/scala/wartremover/ignoreWarts.scala
+++ b/core/src/main/scala/wartremover/ignoreWarts.scala
@@ -1,0 +1,5 @@
+package org.brianmckenna.wartremover
+
+import scala.annotation.StaticAnnotation
+
+class ignoreWarts(warts : String*) extends StaticAnnotation

--- a/core/src/main/scala/wartremover/ignoreWarts.scala
+++ b/core/src/main/scala/wartremover/ignoreWarts.scala
@@ -1,5 +1,0 @@
-package org.brianmckenna.wartremover
-
-import scala.annotation.StaticAnnotation
-
-class ignoreWarts(warts : String*) extends StaticAnnotation

--- a/core/src/main/scala/wartremover/warts/Any2StringAdd.scala
+++ b/core/src/main/scala/wartremover/warts/Any2StringAdd.scala
@@ -10,7 +10,7 @@ object Any2StringAdd extends WartTraverser {
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {
-          // Ignore trees marked by ignoreWarts
+          // Ignore trees marked by SuppressWarnings
           case t if hasWartAnnotation(u)(t) =>
           case Apply(Select(Select(_, PredefName), Any2StringAddName), _) =>
             u.error(tree.pos, "Scala inserted an any2stringadd call")

--- a/core/src/main/scala/wartremover/warts/Any2StringAdd.scala
+++ b/core/src/main/scala/wartremover/warts/Any2StringAdd.scala
@@ -10,13 +10,16 @@ object Any2StringAdd extends WartTraverser {
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {
+          // Ignore trees marked by ignoreWarts
+          case t if hasWartAnnotation(u)(t) =>
           case Apply(Select(Select(_, PredefName), Any2StringAddName), _) =>
             u.error(tree.pos, "Scala inserted an any2stringadd call")
+            super.traverse(tree)
           case TypeApply(Select(Select(_, PredefName), Any2StringAddName), _) =>
             u.error(tree.pos, "Scala inserted an any2stringadd call")
-          case _ =>
+            super.traverse(tree)
+          case _ => super.traverse(tree)
         }
-        super.traverse(tree)
       }
     }
   }

--- a/core/src/main/scala/wartremover/warts/AsInstanceOf.scala
+++ b/core/src/main/scala/wartremover/warts/AsInstanceOf.scala
@@ -17,6 +17,9 @@ object AsInstanceOf extends WartTraverser {
         val synthetic = isSynthetic(u)(tree)
         tree match {
 
+          // Ignore trees marked by ignoreWarts
+          case t if hasWartAnnotation(u)(t) =>
+
           // Ignore usage in synthetic classes
           case ClassDef(_, _, _, _) if synthetic => 
 

--- a/core/src/main/scala/wartremover/warts/AsInstanceOf.scala
+++ b/core/src/main/scala/wartremover/warts/AsInstanceOf.scala
@@ -17,7 +17,7 @@ object AsInstanceOf extends WartTraverser {
         val synthetic = isSynthetic(u)(tree)
         tree match {
 
-          // Ignore trees marked by ignoreWarts
+          // Ignore trees marked by SuppressWarnings
           case t if hasWartAnnotation(u)(t) =>
 
           // Ignore usage in synthetic classes

--- a/core/src/main/scala/wartremover/warts/DefaultArguments.scala
+++ b/core/src/main/scala/wartremover/warts/DefaultArguments.scala
@@ -12,6 +12,8 @@ object DefaultArguments extends WartTraverser {
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {
+          // Ignore trees marked by ignoreWarts
+          case t if hasWartAnnotation(u)(t) =>
           case d@DefDef(_, _, _, vs, _, _) if !isSynthetic(u)(d) && vs.find(containsDef).isDefined =>
             u.error(tree.pos, "Function has default arguments")
           case _ =>

--- a/core/src/main/scala/wartremover/warts/DefaultArguments.scala
+++ b/core/src/main/scala/wartremover/warts/DefaultArguments.scala
@@ -12,7 +12,7 @@ object DefaultArguments extends WartTraverser {
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {
-          // Ignore trees marked by ignoreWarts
+          // Ignore trees marked by SuppressWarnings
           case t if hasWartAnnotation(u)(t) =>
           case d@DefDef(_, _, _, vs, _, _) if !isSynthetic(u)(d) && vs.find(containsDef).isDefined =>
             u.error(tree.pos, "Function has default arguments")

--- a/core/src/main/scala/wartremover/warts/EitherProjectionPartial.scala
+++ b/core/src/main/scala/wartremover/warts/EitherProjectionPartial.scala
@@ -11,7 +11,7 @@ object EitherProjectionPartial extends WartTraverser {
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {
-          // Ignore trees marked by ignoreWarts
+          // Ignore trees marked by SuppressWarnings
           case t if hasWartAnnotation(u)(t) =>
           case Select(left, GetName) if left.tpe.baseType(leftProjectionSymbol) != NoType =>
             u.error(tree.pos, "LeftProjection#get is disabled - use LeftProjection#toOption instead")

--- a/core/src/main/scala/wartremover/warts/EitherProjectionPartial.scala
+++ b/core/src/main/scala/wartremover/warts/EitherProjectionPartial.scala
@@ -11,13 +11,16 @@ object EitherProjectionPartial extends WartTraverser {
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {
+          // Ignore trees marked by ignoreWarts
+          case t if hasWartAnnotation(u)(t) =>
           case Select(left, GetName) if left.tpe.baseType(leftProjectionSymbol) != NoType =>
             u.error(tree.pos, "LeftProjection#get is disabled - use LeftProjection#toOption instead")
+            super.traverse(tree)
           case Select(left, GetName) if left.tpe.baseType(rightProjectionSymbol) != NoType =>
             u.error(tree.pos, "RightProjection#get is disabled - use RightProjection#toOption instead")
-          case _ =>
+            super.traverse(tree)
+          case _ => super.traverse(tree)
         }
-        super.traverse(tree)
       }
     }
   }

--- a/core/src/main/scala/wartremover/warts/ForbidInference.scala
+++ b/core/src/main/scala/wartremover/warts/ForbidInference.scala
@@ -25,7 +25,7 @@ trait ForbidInference[T] extends WartTraverser {
         def error() = u.error(tree.pos, s"Inferred type containing ${tSymbol.name}")
 
         tree match {
-          // Ignore trees marked by ignoreWarts
+          // Ignore trees marked by SuppressWarnings
           case t if hasWartAnnotation(u)(t) =>
           case tpt @ TypeTree() if wasInferred(u)(tpt) && tpt.tpe.contains(tSymbol) =>
             tpt.tpe match {

--- a/core/src/main/scala/wartremover/warts/ForbidInference.scala
+++ b/core/src/main/scala/wartremover/warts/ForbidInference.scala
@@ -25,6 +25,8 @@ trait ForbidInference[T] extends WartTraverser {
         def error() = u.error(tree.pos, s"Inferred type containing ${tSymbol.name}")
 
         tree match {
+          // Ignore trees marked by ignoreWarts
+          case t if hasWartAnnotation(u)(t) =>
           case tpt @ TypeTree() if wasInferred(u)(tpt) && tpt.tpe.contains(tSymbol) =>
             tpt.tpe match {
               // Ignore existential types, they supposedly contain "any"

--- a/core/src/main/scala/wartremover/warts/IsInstanceOf.scala
+++ b/core/src/main/scala/wartremover/warts/IsInstanceOf.scala
@@ -12,6 +12,9 @@ object IsInstanceOf extends WartTraverser {
         val synthetic = isSynthetic(u)(tree)
         tree match {
 
+          // Ignore trees marked by ignoreWarts
+          case t if hasWartAnnotation(u)(t) =>
+
           // Ignore synthetic canEquals() and equals()
           case DefDef(_, CanEqualName | EqualsName, _, _, _, _) if synthetic => 
 

--- a/core/src/main/scala/wartremover/warts/IsInstanceOf.scala
+++ b/core/src/main/scala/wartremover/warts/IsInstanceOf.scala
@@ -12,7 +12,7 @@ object IsInstanceOf extends WartTraverser {
         val synthetic = isSynthetic(u)(tree)
         tree match {
 
-          // Ignore trees marked by ignoreWarts
+          // Ignore trees marked by SuppressWarnings
           case t if hasWartAnnotation(u)(t) =>
 
           // Ignore synthetic canEquals() and equals()

--- a/core/src/main/scala/wartremover/warts/JavaConversions.scala
+++ b/core/src/main/scala/wartremover/warts/JavaConversions.scala
@@ -10,7 +10,7 @@ object JavaConversions extends WartTraverser {
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {
-          // Ignore trees marked by ignoreWarts
+          // Ignore trees marked by SuppressWarnings
           case t if hasWartAnnotation(u)(t) =>
           case Select(tpt, _) if tpt.tpe.contains(javaConversions) => {
             u.error(tree.pos, "scala.collection.JavaConversions is disabled - use scala.collection.JavaConverters instead")

--- a/core/src/main/scala/wartremover/warts/JavaConversions.scala
+++ b/core/src/main/scala/wartremover/warts/JavaConversions.scala
@@ -10,12 +10,14 @@ object JavaConversions extends WartTraverser {
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {
+          // Ignore trees marked by ignoreWarts
+          case t if hasWartAnnotation(u)(t) =>
           case Select(tpt, _) if tpt.tpe.contains(javaConversions) => {
             u.error(tree.pos, "scala.collection.JavaConversions is disabled - use scala.collection.JavaConverters instead")
+            super.traverse(tree)
           }
-          case _ =>
+          case _ => super.traverse(tree)
         }
-        super.traverse(tree)
       }
     }
   }

--- a/core/src/main/scala/wartremover/warts/ListOps.scala
+++ b/core/src/main/scala/wartremover/warts/ListOps.scala
@@ -4,6 +4,8 @@ package warts
 object ListOps extends WartTraverser {
 
   class Op(name: String, error: String) extends WartTraverser {
+    override lazy val className = "org.brianmckenna.wartremover.warts.ListOps"
+
     def apply(u: WartUniverse): u.Traverser = {
       import u.universe._
 
@@ -12,6 +14,8 @@ object ListOps extends WartTraverser {
       new u.Traverser {
         override def traverse(tree: Tree): Unit = {
           tree match {
+            // Ignore trees marked by ignoreWarts
+            case t if hasWartAnnotation(u)(t) =>
             case Select(left, Name) if left.tpe.baseType(listSymbol) != NoType ⇒
               u.error(tree.pos, error)
             // TODO: This ignores a lot

--- a/core/src/main/scala/wartremover/warts/ListOps.scala
+++ b/core/src/main/scala/wartremover/warts/ListOps.scala
@@ -14,7 +14,7 @@ object ListOps extends WartTraverser {
       new u.Traverser {
         override def traverse(tree: Tree): Unit = {
           tree match {
-            // Ignore trees marked by ignoreWarts
+            // Ignore trees marked by SuppressWarnings
             case t if hasWartAnnotation(u)(t) =>
             case Select(left, Name) if left.tpe.baseType(listSymbol) != NoType ⇒
               u.error(tree.pos, error)

--- a/core/src/main/scala/wartremover/warts/MutableDataStructures.scala
+++ b/core/src/main/scala/wartremover/warts/MutableDataStructures.scala
@@ -10,11 +10,13 @@ object MutableDataStructures extends WartTraverser {
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {
+          // Ignore trees marked by ignoreWarts
+          case t if hasWartAnnotation(u)(t) =>
           case Select(tpt, _) if tpt.tpe.contains(mutablePackage) && tpt.tpe.termSymbol.isPackage =>
             u.error(tree.pos, "scala.collection.mutable package is disabled")
-          case _ =>
+            super.traverse(tree)
+          case _ => super.traverse(tree)
         }
-        super.traverse(tree)
       }
     }
   }

--- a/core/src/main/scala/wartremover/warts/MutableDataStructures.scala
+++ b/core/src/main/scala/wartremover/warts/MutableDataStructures.scala
@@ -10,7 +10,7 @@ object MutableDataStructures extends WartTraverser {
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {
-          // Ignore trees marked by ignoreWarts
+          // Ignore trees marked by SuppressWarnings
           case t if hasWartAnnotation(u)(t) =>
           case Select(tpt, _) if tpt.tpe.contains(mutablePackage) && tpt.tpe.termSymbol.isPackage =>
             u.error(tree.pos, "scala.collection.mutable package is disabled")

--- a/core/src/main/scala/wartremover/warts/NoNeedForMonad.scala
+++ b/core/src/main/scala/wartremover/warts/NoNeedForMonad.scala
@@ -68,6 +68,8 @@ object NoNeedForMonad extends WartTraverser {
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {
+          // Ignore trees marked by ignoreWarts
+          case t if hasWartAnnotation(u)(t) =>
           // Note: first two cases currently don't not work in 2.10: https://github.com/scalamacros/paradise/issues/38
           // Will propagate to matching desugared chain of maps/flatMaps.
           case q"for (..$enums) yield $body"                                                        => processForComprehension(tree, enums, body)

--- a/core/src/main/scala/wartremover/warts/NoNeedForMonad.scala
+++ b/core/src/main/scala/wartremover/warts/NoNeedForMonad.scala
@@ -68,7 +68,7 @@ object NoNeedForMonad extends WartTraverser {
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {
-          // Ignore trees marked by ignoreWarts
+          // Ignore trees marked by SuppressWarnings
           case t if hasWartAnnotation(u)(t) =>
           // Note: first two cases currently don't not work in 2.10: https://github.com/scalamacros/paradise/issues/38
           // Will propagate to matching desugared chain of maps/flatMaps.

--- a/core/src/main/scala/wartremover/warts/NonUnitStatements.scala
+++ b/core/src/main/scala/wartremover/warts/NonUnitStatements.scala
@@ -34,7 +34,7 @@ object NonUnitStatements extends WartTraverser {
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {
-          // Ignore trees marked by ignoreWarts
+          // Ignore trees marked by SuppressWarnings
           case t if hasWartAnnotation(u)(t) =>
           case Block(statements, _) =>
             checkUnitLike(statements)

--- a/core/src/main/scala/wartremover/warts/NonUnitStatements.scala
+++ b/core/src/main/scala/wartremover/warts/NonUnitStatements.scala
@@ -34,15 +34,19 @@ object NonUnitStatements extends WartTraverser {
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {
+          // Ignore trees marked by ignoreWarts
+          case t if hasWartAnnotation(u)(t) =>
           case Block(statements, _) =>
             checkUnitLike(statements)
+            super.traverse(tree)
           case ClassDef(_, _, _, Template((_, _, statements))) =>
             checkUnitLike(statements)
+            super.traverse(tree)
           case ModuleDef(_, _, Template((_, _, statements))) =>
             checkUnitLike(statements)
-          case _ =>
+            super.traverse(tree)
+          case _ => super.traverse(tree)
         }
-        super.traverse(tree)
       }
     }
   }

--- a/core/src/main/scala/wartremover/warts/Null.scala
+++ b/core/src/main/scala/wartremover/warts/Null.scala
@@ -16,7 +16,7 @@ object Null extends WartTraverser {
       override def traverse(tree: Tree): Unit = {
         val synthetic = isSynthetic(u)(tree)
         tree match {
-          // Ignore trees marked by ignoreWarts
+          // Ignore trees marked by SuppressWarnings
           case t if hasWartAnnotation(u)(t) =>
           // Ignore xml literals
           case Apply(Select(left, _), _) if xmlSymbols.contains(left.tpe.typeSymbol.fullName) =>

--- a/core/src/main/scala/wartremover/warts/Null.scala
+++ b/core/src/main/scala/wartremover/warts/Null.scala
@@ -16,6 +16,8 @@ object Null extends WartTraverser {
       override def traverse(tree: Tree): Unit = {
         val synthetic = isSynthetic(u)(tree)
         tree match {
+          // Ignore trees marked by ignoreWarts
+          case t if hasWartAnnotation(u)(t) =>
           // Ignore xml literals
           case Apply(Select(left, _), _) if xmlSymbols.contains(left.tpe.typeSymbol.fullName) =>
           // Ignore synthetic case class's companion object unapply

--- a/core/src/main/scala/wartremover/warts/OptionPartial.scala
+++ b/core/src/main/scala/wartremover/warts/OptionPartial.scala
@@ -10,7 +10,7 @@ object OptionPartial extends WartTraverser {
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {
-          // Ignore trees marked by ignoreWarts
+          // Ignore trees marked by SuppressWarnings
           case t if hasWartAnnotation(u)(t) =>
           case Select(left, GetName) if left.tpe.baseType(optionSymbol) != NoType =>
             u.error(tree.pos, "Option#get is disabled - use Option#fold instead")

--- a/core/src/main/scala/wartremover/warts/OptionPartial.scala
+++ b/core/src/main/scala/wartremover/warts/OptionPartial.scala
@@ -10,6 +10,8 @@ object OptionPartial extends WartTraverser {
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {
+          // Ignore trees marked by ignoreWarts
+          case t if hasWartAnnotation(u)(t) =>
           case Select(left, GetName) if left.tpe.baseType(optionSymbol) != NoType =>
             u.error(tree.pos, "Option#get is disabled - use Option#fold instead")
           // TODO: This ignores a lot

--- a/core/src/main/scala/wartremover/warts/Return.scala
+++ b/core/src/main/scala/wartremover/warts/Return.scala
@@ -7,7 +7,7 @@ object Return extends WartTraverser {
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {
-          // Ignore trees marked by ignoreWarts
+          // Ignore trees marked by SuppressWarnings
           case t if hasWartAnnotation(u)(t) =>
           case u.universe.Return(_) =>
             u.error(tree.pos, "return is disabled")

--- a/core/src/main/scala/wartremover/warts/Return.scala
+++ b/core/src/main/scala/wartremover/warts/Return.scala
@@ -7,6 +7,8 @@ object Return extends WartTraverser {
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {
+          // Ignore trees marked by ignoreWarts
+          case t if hasWartAnnotation(u)(t) =>
           case u.universe.Return(_) =>
             u.error(tree.pos, "return is disabled")
           case _ =>

--- a/core/src/main/scala/wartremover/warts/Throw.scala
+++ b/core/src/main/scala/wartremover/warts/Throw.scala
@@ -8,6 +8,8 @@ object Throw extends WartTraverser {
     new u.Traverser {
       override def traverse(tree: Tree) {
         tree match {
+          // Ignore trees marked by ignoreWarts
+          case t if hasWartAnnotation(u)(t) =>
           case dd@DefDef(_, ProductElementName , _, _, _, _) if isSynthetic(u)(dd) =>
           case u.universe.Throw(_) =>
             u.error(tree.pos, "throw is disabled")

--- a/core/src/main/scala/wartremover/warts/Throw.scala
+++ b/core/src/main/scala/wartremover/warts/Throw.scala
@@ -8,7 +8,7 @@ object Throw extends WartTraverser {
     new u.Traverser {
       override def traverse(tree: Tree) {
         tree match {
-          // Ignore trees marked by ignoreWarts
+          // Ignore trees marked by SuppressWarnings
           case t if hasWartAnnotation(u)(t) =>
           case dd@DefDef(_, ProductElementName , _, _, _, _) if isSynthetic(u)(dd) =>
           case u.universe.Throw(_) =>

--- a/core/src/main/scala/wartremover/warts/TryPartial.scala
+++ b/core/src/main/scala/wartremover/warts/TryPartial.scala
@@ -10,7 +10,7 @@ object TryPartial extends WartTraverser {
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {
-          // Ignore trees marked by ignoreWarts
+          // Ignore trees marked by SuppressWarnings
           case t if hasWartAnnotation(u)(t) =>
           case Select(left, GetName) if left.tpe.baseType(optionSymbol) != NoType =>
             u.error(tree.pos, "Try#get is disabled")

--- a/core/src/main/scala/wartremover/warts/TryPartial.scala
+++ b/core/src/main/scala/wartremover/warts/TryPartial.scala
@@ -10,6 +10,8 @@ object TryPartial extends WartTraverser {
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {
+          // Ignore trees marked by ignoreWarts
+          case t if hasWartAnnotation(u)(t) =>
           case Select(left, GetName) if left.tpe.baseType(optionSymbol) != NoType =>
             u.error(tree.pos, "Try#get is disabled")
           case LabelDef(_, _, rhs) if isSynthetic(u)(tree)=>

--- a/core/src/main/scala/wartremover/warts/Var.scala
+++ b/core/src/main/scala/wartremover/warts/Var.scala
@@ -17,7 +17,7 @@ object Var extends WartTraverser {
       override def traverse(tree: Tree): Unit = {
         val synthetic = isSynthetic(u)(tree)
         tree match {
-          // Ignore trees marked by ignoreWarts
+          // Ignore trees marked by SuppressWarnings
           case t if hasWartAnnotation(u)(t) =>
           // Ignore case class's synthetic hashCode
           case ClassDef(mods, _, tparams, Template(parents, self, stats)) if mods.hasFlag(Flag.CASE) =>

--- a/core/src/main/scala/wartremover/warts/Var.scala
+++ b/core/src/main/scala/wartremover/warts/Var.scala
@@ -17,6 +17,8 @@ object Var extends WartTraverser {
       override def traverse(tree: Tree): Unit = {
         val synthetic = isSynthetic(u)(tree)
         tree match {
+          // Ignore trees marked by ignoreWarts
+          case t if hasWartAnnotation(u)(t) =>
           // Ignore case class's synthetic hashCode
           case ClassDef(mods, _, tparams, Template(parents, self, stats)) if mods.hasFlag(Flag.CASE) =>
             mods.annotations foreach { annotation =>

--- a/core/src/test/scala/wartremover/warts/Any2StringAddTest.scala
+++ b/core/src/test/scala/wartremover/warts/Any2StringAddTest.scala
@@ -13,4 +13,12 @@ class Any2StringAddTest extends FunSuite {
     assertResult(List("Scala inserted an any2stringadd call"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
+  test("any2stringadd wart obeys ignoreWarts") {
+    val result = WartTestTraverser(Any2StringAdd) {
+      @ignoreWarts("org.brianmckenna.wartremover.warts.Any2StringAdd")
+      val foo = {} + "lol"
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
 }

--- a/core/src/test/scala/wartremover/warts/Any2StringAddTest.scala
+++ b/core/src/test/scala/wartremover/warts/Any2StringAddTest.scala
@@ -13,9 +13,9 @@ class Any2StringAddTest extends FunSuite {
     assertResult(List("Scala inserted an any2stringadd call"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
-  test("any2stringadd wart obeys ignoreWarts") {
+  test("any2stringadd wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Any2StringAdd) {
-      @ignoreWarts("org.brianmckenna.wartremover.warts.Any2StringAdd")
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Any2StringAdd"))
       val foo = {} + "lol"
     }
     assertResult(List.empty, "result.errors")(result.errors)

--- a/core/src/test/scala/wartremover/warts/AnyTest.scala
+++ b/core/src/test/scala/wartremover/warts/AnyTest.scala
@@ -14,4 +14,13 @@ class AnyTest extends FunSuite {
     assertResult(List("Inferred type containing Any"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
+  test("Any wart obeys ignoreWarts") {
+    val result = WartTestTraverser(Any) {
+      @ignoreWarts("org.brianmckenna.wartremover.warts.Any")
+      val x = readf1("{0}")
+      x
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
 }

--- a/core/src/test/scala/wartremover/warts/AnyTest.scala
+++ b/core/src/test/scala/wartremover/warts/AnyTest.scala
@@ -14,9 +14,9 @@ class AnyTest extends FunSuite {
     assertResult(List("Inferred type containing Any"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
-  test("Any wart obeys ignoreWarts") {
+  test("Any wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Any) {
-      @ignoreWarts("org.brianmckenna.wartremover.warts.Any")
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Any"))
       val x = readf1("{0}")
       x
     }

--- a/core/src/test/scala/wartremover/warts/AsInstanceOfTest.scala
+++ b/core/src/test/scala/wartremover/warts/AsInstanceOfTest.scala
@@ -13,9 +13,9 @@ class AsInstanceOfTest extends FunSuite {
     assertResult(List("asInstanceOf is disabled"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
-  test("asInstanceOf wart obeys ignoreWarts") {
+  test("asInstanceOf wart obeys SuppressWarnings") {
     val result = WartTestTraverser(AsInstanceOf) {
-      @ignoreWarts("org.brianmckenna.wartremover.warts.AsInstanceOf")
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.AsInstanceOf"))
       val foo = "abc".asInstanceOf[String]
     }
     assertResult(List.empty, "result.errors")(result.errors)

--- a/core/src/test/scala/wartremover/warts/AsInstanceOfTest.scala
+++ b/core/src/test/scala/wartremover/warts/AsInstanceOfTest.scala
@@ -13,4 +13,12 @@ class AsInstanceOfTest extends FunSuite {
     assertResult(List("asInstanceOf is disabled"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
+  test("asInstanceOf wart obeys ignoreWarts") {
+    val result = WartTestTraverser(AsInstanceOf) {
+      @ignoreWarts("org.brianmckenna.wartremover.warts.AsInstanceOf")
+      val foo = "abc".asInstanceOf[String]
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
 }

--- a/core/src/test/scala/wartremover/warts/DefaultArgumentsTest.scala
+++ b/core/src/test/scala/wartremover/warts/DefaultArgumentsTest.scala
@@ -13,4 +13,12 @@ class DefaultArgumentsTest extends FunSuite {
     assertResult(List("Function has default arguments"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
+  test("Default arguments wart obeys ignoreWarts") {
+    val result = WartTestTraverser(DefaultArguments) {
+      @ignoreWarts("org.brianmckenna.wartremover.warts.DefaultArguments")
+      def x(y: Int = 4) = y
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
 }

--- a/core/src/test/scala/wartremover/warts/DefaultArgumentsTest.scala
+++ b/core/src/test/scala/wartremover/warts/DefaultArgumentsTest.scala
@@ -13,9 +13,9 @@ class DefaultArgumentsTest extends FunSuite {
     assertResult(List("Function has default arguments"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
-  test("Default arguments wart obeys ignoreWarts") {
+  test("Default arguments wart obeys SuppressWarnings") {
     val result = WartTestTraverser(DefaultArguments) {
-      @ignoreWarts("org.brianmckenna.wartremover.warts.DefaultArguments")
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.DefaultArguments"))
       def x(y: Int = 4) = y
     }
     assertResult(List.empty, "result.errors")(result.errors)

--- a/core/src/test/scala/wartremover/warts/EitherProjectionPartialTest.scala
+++ b/core/src/test/scala/wartremover/warts/EitherProjectionPartialTest.scala
@@ -34,9 +34,9 @@ class EitherProjectionPartialTest extends FunSuite {
     assertResult(List("RightProjection#get is disabled - use RightProjection#toOption instead"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
-  test("EitherProjectionPartial wart obeys ignoreWarts") {
+  test("EitherProjectionPartial wart obeys SuppressWarnings") {
     val result = WartTestTraverser(EitherProjectionPartial) {
-      @ignoreWarts("org.brianmckenna.wartremover.warts.EitherProjectionPartial")
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.EitherProjectionPartial"))
       val foo = {
         println(Left(1).left.get)
         println(Right(1).left.get)

--- a/core/src/test/scala/wartremover/warts/EitherProjectionPartialTest.scala
+++ b/core/src/test/scala/wartremover/warts/EitherProjectionPartialTest.scala
@@ -34,4 +34,17 @@ class EitherProjectionPartialTest extends FunSuite {
     assertResult(List("RightProjection#get is disabled - use RightProjection#toOption instead"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
+  test("EitherProjectionPartial wart obeys ignoreWarts") {
+    val result = WartTestTraverser(EitherProjectionPartial) {
+      @ignoreWarts("org.brianmckenna.wartremover.warts.EitherProjectionPartial")
+      val foo = {
+        println(Left(1).left.get)
+        println(Right(1).left.get)
+        println(Left(1).right.get)
+        println(Right(1).right.get)
+      }
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
 }

--- a/core/src/test/scala/wartremover/warts/IsInstanceOfTest.scala
+++ b/core/src/test/scala/wartremover/warts/IsInstanceOfTest.scala
@@ -13,4 +13,12 @@ class IsInstanceOfTest extends FunSuite {
     assertResult(List("isInstanceOf is disabled"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
+  test("isInstanceOf wart obeys ignoreWarts") {
+    val result = WartTestTraverser(IsInstanceOf) {
+      @ignoreWarts("org.brianmckenna.wartremover.warts.IsInstanceOf")
+      val foo = "abc".isInstanceOf[String]
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
 }

--- a/core/src/test/scala/wartremover/warts/IsInstanceOfTest.scala
+++ b/core/src/test/scala/wartremover/warts/IsInstanceOfTest.scala
@@ -13,9 +13,9 @@ class IsInstanceOfTest extends FunSuite {
     assertResult(List("isInstanceOf is disabled"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
-  test("isInstanceOf wart obeys ignoreWarts") {
+  test("isInstanceOf wart obeys SuppressWarnings") {
     val result = WartTestTraverser(IsInstanceOf) {
-      @ignoreWarts("org.brianmckenna.wartremover.warts.IsInstanceOf")
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.IsInstanceOf"))
       val foo = "abc".isInstanceOf[String]
     }
     assertResult(List.empty, "result.errors")(result.errors)

--- a/core/src/test/scala/wartremover/warts/JavaConversionsTest.scala
+++ b/core/src/test/scala/wartremover/warts/JavaConversionsTest.scala
@@ -25,9 +25,9 @@ class JavaConversionsTest extends FunSuite {
     assertResult(List.empty, "result.warnings")(result.warnings)
    
   }
-  test("JavaConversions wart obeys ignoreWarts") {
+  test("JavaConversions wart obeys SuppressWarnings") {
     val result = WartTestTraverser(JavaConversions) {
-      @ignoreWarts("org.brianmckenna.wartremover.warts.JavaConversions")
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.JavaConversions"))
       def ff[A](it: Iterable[A]) = collection.JavaConversions.asJavaCollection(it)
     }
     assertResult(List.empty, "result.errors")(result.errors)

--- a/core/src/test/scala/wartremover/warts/JavaConversionsTest.scala
+++ b/core/src/test/scala/wartremover/warts/JavaConversionsTest.scala
@@ -14,7 +14,7 @@ class JavaConversionsTest extends FunSuite {
     assertResult(List("scala.collection.JavaConversions is disabled - use scala.collection.JavaConverters instead"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
    
-  }  
+  }
   test("disable scala.collection.JavaConversions when referenced in an import") {
     val result = WartTestTraverser(JavaConversions) {
       import scala.collection.JavaConversions._
@@ -24,5 +24,14 @@ class JavaConversionsTest extends FunSuite {
     assertResult(List("scala.collection.JavaConversions is disabled - use scala.collection.JavaConverters instead"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
    
-  } 
+  }
+  test("JavaConversions wart obeys ignoreWarts") {
+    val result = WartTestTraverser(JavaConversions) {
+      @ignoreWarts("org.brianmckenna.wartremover.warts.JavaConversions")
+      def ff[A](it: Iterable[A]) = collection.JavaConversions.asJavaCollection(it)
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+   
+  }
 }

--- a/core/src/test/scala/wartremover/warts/ListTest.scala
+++ b/core/src/test/scala/wartremover/warts/ListTest.scala
@@ -62,9 +62,9 @@ class ListTest extends FunSuite {
     expectResult(List.empty, "result.warnings")(result.warnings)
   }
 
-  test("ListOps wart obeys ignoreWarts") {
+  test("ListOps wart obeys SuppressWarnings") {
     val result = WartTestTraverser(ListOps) {
-      @ignoreWarts("org.brianmckenna.wartremover.warts.ListOps")
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.ListOps"))
       val foo = {
         println(List(1).head)
         println(List().tail)

--- a/core/src/test/scala/wartremover/warts/ListTest.scala
+++ b/core/src/test/scala/wartremover/warts/ListTest.scala
@@ -62,4 +62,21 @@ class ListTest extends FunSuite {
     expectResult(List.empty, "result.warnings")(result.warnings)
   }
 
+  test("ListOps wart obeys ignoreWarts") {
+    val result = WartTestTraverser(ListOps) {
+      @ignoreWarts("org.brianmckenna.wartremover.warts.ListOps")
+      val foo = {
+        println(List(1).head)
+        println(List().tail)
+        println(List().init)
+        println(List().last)
+        println(List.empty[Int].reduce(_ + _))
+        println(List.empty[Int].reduceLeft(_ + _))
+        println(List.empty[Int].reduceRight(_ + _))
+      }
+    }
+    expectResult(List.empty, "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
+  }
+
 }

--- a/core/src/test/scala/wartremover/warts/MutableDataStructuresTest.scala
+++ b/core/src/test/scala/wartremover/warts/MutableDataStructuresTest.scala
@@ -20,9 +20,9 @@ class MutableDataStructuresTest extends FunSuite {
     assertResult(List.empty, "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
-  test("MutableDataStructures wart obeys ignoreWarts") {
+  test("MutableDataStructures wart obeys SuppressWarnings") {
     val result = WartTestTraverser(MutableDataStructures) {
-      @ignoreWarts("org.brianmckenna.wartremover.warts.MutableDataStructures")
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.MutableDataStructures"))
       var x = scala.collection.mutable.HashMap("key" -> "value")
     }
     assertResult(List.empty, "result.errors")(result.errors)

--- a/core/src/test/scala/wartremover/warts/MutableDataStructuresTest.scala
+++ b/core/src/test/scala/wartremover/warts/MutableDataStructuresTest.scala
@@ -20,4 +20,12 @@ class MutableDataStructuresTest extends FunSuite {
     assertResult(List.empty, "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
+  test("MutableDataStructures wart obeys ignoreWarts") {
+    val result = WartTestTraverser(MutableDataStructures) {
+      @ignoreWarts("org.brianmckenna.wartremover.warts.MutableDataStructures")
+      var x = scala.collection.mutable.HashMap("key" -> "value")
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
 }

--- a/core/src/test/scala/wartremover/warts/NoNeedForMonadTest.scala
+++ b/core/src/test/scala/wartremover/warts/NoNeedForMonadTest.scala
@@ -68,9 +68,9 @@ class NoNeedForMonadTest extends FunSuite {
     assertResult(List.empty, "result.errors")(extendsFunction.warnings)
   }
 
-  test("NoNeedForMonad wart obeys ignoreWarts") {
+  test("NoNeedForMonad wart obeys SuppressWarnings") {
     val result = WartTestTraverser(NoNeedForMonad) {
-      @ignoreWarts("org.brianmckenna.wartremover.warts.NoNeedForMonad")
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.NoNeedForMonad"))
       val foo = {
         for {
           x <- List(1, 2, 3)

--- a/core/src/test/scala/wartremover/warts/NoNeedForMonadTest.scala
+++ b/core/src/test/scala/wartremover/warts/NoNeedForMonadTest.scala
@@ -67,4 +67,21 @@ class NoNeedForMonadTest extends FunSuite {
     assertResult(List.empty, "result.errors")(extendsFunction.errors)
     assertResult(List.empty, "result.errors")(extendsFunction.warnings)
   }
+
+  test("NoNeedForMonad wart obeys ignoreWarts") {
+    val result = WartTestTraverser(NoNeedForMonad) {
+      @ignoreWarts("org.brianmckenna.wartremover.warts.NoNeedForMonad")
+      val foo = {
+        for {
+          x <- List(1, 2, 3)
+          y <- List(2, 3, 4)
+        } yield x * y
+  
+        Option(1).flatMap(i => Option(2).map(j => i + j))
+      }
+    }
+
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
 }

--- a/core/src/test/scala/wartremover/warts/NonUnitStatementsTest.scala
+++ b/core/src/test/scala/wartremover/warts/NonUnitStatementsTest.scala
@@ -22,4 +22,15 @@ class NonUnitStatementsTest extends FunSuite {
     assertResult(List.empty, "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
+  test("NonUnitStatements wart obeys ignoreWarts") {
+    val result = WartTestTraverser(NonUnitStatements) {
+      @ignoreWarts("org.brianmckenna.wartremover.warts.NonUnitStatements")
+      val foo = {
+        1
+        2
+      }
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
 }

--- a/core/src/test/scala/wartremover/warts/NonUnitStatementsTest.scala
+++ b/core/src/test/scala/wartremover/warts/NonUnitStatementsTest.scala
@@ -22,9 +22,9 @@ class NonUnitStatementsTest extends FunSuite {
     assertResult(List.empty, "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
-  test("NonUnitStatements wart obeys ignoreWarts") {
+  test("NonUnitStatements wart obeys SuppressWarnings") {
     val result = WartTestTraverser(NonUnitStatements) {
-      @ignoreWarts("org.brianmckenna.wartremover.warts.NonUnitStatements")
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.NonUnitStatements"))
       val foo = {
         1
         2

--- a/core/src/test/scala/wartremover/warts/NothingTest.scala
+++ b/core/src/test/scala/wartremover/warts/NothingTest.scala
@@ -14,9 +14,9 @@ class NothingTest extends FunSuite {
     assertResult(List("Inferred type containing Nothing"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
-  test("Nothing wart obeys ignoreWarts") {
+  test("Nothing wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Nothing) {
-      @ignoreWarts("org.brianmckenna.wartremover.warts.Nothing")
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Nothing"))
       val x = ???
       x
     }

--- a/core/src/test/scala/wartremover/warts/NothingTest.scala
+++ b/core/src/test/scala/wartremover/warts/NothingTest.scala
@@ -14,4 +14,13 @@ class NothingTest extends FunSuite {
     assertResult(List("Inferred type containing Nothing"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
+  test("Nothing wart obeys ignoreWarts") {
+    val result = WartTestTraverser(Nothing) {
+      @ignoreWarts("org.brianmckenna.wartremover.warts.Nothing")
+      val x = ???
+      x
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
 }

--- a/core/src/test/scala/wartremover/warts/NullTest.scala
+++ b/core/src/test/scala/wartremover/warts/NullTest.scala
@@ -28,4 +28,17 @@ class NullTest extends FunSuite {
     assertResult(List("null is disabled"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
+  test("Null wart obeys ignoreWarts") {
+    val result = WartTestTraverser(Null) {
+      @ignoreWarts("org.brianmckenna.wartremover.warts.Null")
+      val foo = {
+        println(null)
+        val (a, b) = (1, null)
+        println(a)
+        Map(1 -> "one", 2 -> "two").partition { case (k, v) => null.asInstanceOf[Boolean] }
+      }
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
 }

--- a/core/src/test/scala/wartremover/warts/NullTest.scala
+++ b/core/src/test/scala/wartremover/warts/NullTest.scala
@@ -28,9 +28,9 @@ class NullTest extends FunSuite {
     assertResult(List("null is disabled"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
-  test("Null wart obeys ignoreWarts") {
+  test("Null wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Null) {
-      @ignoreWarts("org.brianmckenna.wartremover.warts.Null")
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Null"))
       val foo = {
         println(null)
         val (a, b) = (1, null)

--- a/core/src/test/scala/wartremover/warts/OptionPartialTest.scala
+++ b/core/src/test/scala/wartremover/warts/OptionPartialTest.scala
@@ -28,9 +28,9 @@ class OptionPartialTest extends FunSuite {
     assertResult(List.empty, "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
-  test("OptionPartial wart obeys ignoreWarts") {
+  test("OptionPartial wart obeys SuppressWarnings") {
     val result = WartTestTraverser(OptionPartial) {
-      @ignoreWarts("org.brianmckenna.wartremover.warts.OptionPartial")
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.OptionPartial"))
       val foo = {
         println(Some(1).get)
         println(None.get)

--- a/core/src/test/scala/wartremover/warts/OptionPartialTest.scala
+++ b/core/src/test/scala/wartremover/warts/OptionPartialTest.scala
@@ -28,4 +28,15 @@ class OptionPartialTest extends FunSuite {
     assertResult(List.empty, "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
+  test("OptionPartial wart obeys ignoreWarts") {
+    val result = WartTestTraverser(OptionPartial) {
+      @ignoreWarts("org.brianmckenna.wartremover.warts.OptionPartial")
+      val foo = {
+        println(Some(1).get)
+        println(None.get)
+      }
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
 }

--- a/core/src/test/scala/wartremover/warts/ProductTest.scala
+++ b/core/src/test/scala/wartremover/warts/ProductTest.scala
@@ -13,4 +13,12 @@ class ProductTest extends FunSuite {
     assertResult(List("Inferred type containing Product"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
+  test("Product wart obeys ignoreWarts") {
+    val result = WartTestTraverser(Product) {
+      @ignoreWarts("org.brianmckenna.wartremover.warts.Product")
+      val foo = List((1, 2, 3), (1, 2))
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
 }

--- a/core/src/test/scala/wartremover/warts/ProductTest.scala
+++ b/core/src/test/scala/wartremover/warts/ProductTest.scala
@@ -13,9 +13,9 @@ class ProductTest extends FunSuite {
     assertResult(List("Inferred type containing Product"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
-  test("Product wart obeys ignoreWarts") {
+  test("Product wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Product) {
-      @ignoreWarts("org.brianmckenna.wartremover.warts.Product")
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Product"))
       val foo = List((1, 2, 3), (1, 2))
     }
     assertResult(List.empty, "result.errors")(result.errors)

--- a/core/src/test/scala/wartremover/warts/ReturnTest.scala
+++ b/core/src/test/scala/wartremover/warts/ReturnTest.scala
@@ -20,4 +20,14 @@ class ReturnTest extends FunSuite {
     assertResult(List("return is disabled"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
+  test("Return wart is disabled") {
+    val result = WartTestTraverser(Return) {
+      @ignoreWarts("org.brianmckenna.wartremover.warts.Return")
+      def foo(n:Int): Int = return n + 1
+      @ignoreWarts("org.brianmckenna.wartremover.warts.Return")
+      def bar(ns: List[Int]): Any = ns.map(n => return n + 1)
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
 }

--- a/core/src/test/scala/wartremover/warts/ReturnTest.scala
+++ b/core/src/test/scala/wartremover/warts/ReturnTest.scala
@@ -22,9 +22,9 @@ class ReturnTest extends FunSuite {
   }
   test("Return wart is disabled") {
     val result = WartTestTraverser(Return) {
-      @ignoreWarts("org.brianmckenna.wartremover.warts.Return")
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Return"))
       def foo(n:Int): Int = return n + 1
-      @ignoreWarts("org.brianmckenna.wartremover.warts.Return")
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Return"))
       def bar(ns: List[Int]): Any = ns.map(n => return n + 1)
     }
     assertResult(List.empty, "result.errors")(result.errors)

--- a/core/src/test/scala/wartremover/warts/SerializableTest.scala
+++ b/core/src/test/scala/wartremover/warts/SerializableTest.scala
@@ -13,9 +13,9 @@ class SerializableTest extends FunSuite {
     assertResult(List("Inferred type containing Serializable"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
-  test("Serializable wart obeys ignoreWarts") {
+  test("Serializable wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Serializable) {
-      @ignoreWarts("org.brianmckenna.wartremover.warts.Serializable")
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Serializable"))
       val foo = List((1, 2, 3), (1, 2))
     }
     assertResult(List.empty, "result.errors")(result.errors)

--- a/core/src/test/scala/wartremover/warts/SerializableTest.scala
+++ b/core/src/test/scala/wartremover/warts/SerializableTest.scala
@@ -13,4 +13,12 @@ class SerializableTest extends FunSuite {
     assertResult(List("Inferred type containing Serializable"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
+  test("Serializable wart obeys ignoreWarts") {
+    val result = WartTestTraverser(Serializable) {
+      @ignoreWarts("org.brianmckenna.wartremover.warts.Serializable")
+      val foo = List((1, 2, 3), (1, 2))
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
 }

--- a/core/src/test/scala/wartremover/warts/ThrowTest.scala
+++ b/core/src/test/scala/wartremover/warts/ThrowTest.scala
@@ -21,4 +21,13 @@ class ThrowTest extends FunSuite {
     assertResult(List.empty, "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
+
+  test("Throw wart obeys ignoreWarts") {
+    val result = WartTestTraverser(Throw) {
+      @ignoreWarts("org.brianmckenna.wartremover.warts.Throw")
+      def foo(n: Int): Int = throw new IllegalArgumentException("bar")
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
 }

--- a/core/src/test/scala/wartremover/warts/ThrowTest.scala
+++ b/core/src/test/scala/wartremover/warts/ThrowTest.scala
@@ -22,9 +22,9 @@ class ThrowTest extends FunSuite {
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
 
-  test("Throw wart obeys ignoreWarts") {
+  test("Throw wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Throw) {
-      @ignoreWarts("org.brianmckenna.wartremover.warts.Throw")
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Throw"))
       def foo(n: Int): Int = throw new IllegalArgumentException("bar")
     }
     assertResult(List.empty, "result.errors")(result.errors)

--- a/core/src/test/scala/wartremover/warts/TryPartialTest.scala
+++ b/core/src/test/scala/wartremover/warts/TryPartialTest.scala
@@ -28,9 +28,9 @@ class TryPartialTest extends FunSuite {
     assertResult(List.empty, "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
-  test("TryPartial wart obeys ignoreWarts") {
+  test("TryPartial wart obeys SuppressWarnings") {
     val result = WartTestTraverser(TryPartial) {
-      @ignoreWarts("org.brianmckenna.wartremover.warts.TryPartial")
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.TryPartial"))
       val foo = {
         println(Success(1).get)
         println(Failure(new Error).get)

--- a/core/src/test/scala/wartremover/warts/TryPartialTest.scala
+++ b/core/src/test/scala/wartremover/warts/TryPartialTest.scala
@@ -28,4 +28,15 @@ class TryPartialTest extends FunSuite {
     assertResult(List.empty, "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
+  test("TryPartial wart obeys ignoreWarts") {
+    val result = WartTestTraverser(TryPartial) {
+      @ignoreWarts("org.brianmckenna.wartremover.warts.TryPartial")
+      val foo = {
+        println(Success(1).get)
+        println(Failure(new Error).get)
+      }
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
 }

--- a/core/src/test/scala/wartremover/warts/VarTest.scala
+++ b/core/src/test/scala/wartremover/warts/VarTest.scala
@@ -14,4 +14,13 @@ class VarTest extends FunSuite {
     assertResult(List("var is disabled"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
+  test("Var wart obeys ignoreWarts") {
+    val result = WartTestTraverser(Var) {
+      @ignoreWarts("org.brianmckenna.wartremover.warts.Var")
+      var x = 10
+      x
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
 }

--- a/core/src/test/scala/wartremover/warts/VarTest.scala
+++ b/core/src/test/scala/wartremover/warts/VarTest.scala
@@ -14,9 +14,9 @@ class VarTest extends FunSuite {
     assertResult(List("var is disabled"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
-  test("Var wart obeys ignoreWarts") {
+  test("Var wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Var) {
-      @ignoreWarts("org.brianmckenna.wartremover.warts.Var")
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Var"))
       var x = 10
       x
     }


### PR DESCRIPTION
This Pull Request adds an `ignoreWarts` annotation which allows the user to ignore the specified warts in the annotated code. This accomplishes the "exceptions" half of https://github.com/puffnfresh/wartremover/issues/92 but not the "include" half.

Because wartremover runs after the typer-phase I couldn't inject the annotation into the code using the plugin so the user must add wartremover as a library dpendency.