### PR TITLE
Add a FinalCaseClass wart that enforces the final modifier on case classes

### DIFF
--- a/core/src/main/scala/wartremover/warts/FinalCaseClass.scala
+++ b/core/src/main/scala/wartremover/warts/FinalCaseClass.scala
@@ -1,0 +1,24 @@
+package org.brianmckenna.wartremover
+package warts
+
+object FinalCaseClass extends WartTraverser {
+  def apply(u: WartUniverse): u.Traverser = {
+    import u.universe._
+    import u.universe.Flag._
+
+    new u.Traverser {
+      override def traverse(tree: Tree): Unit = {
+        tree match {
+          // Ignore trees marked by SuppressWarnings
+          case t if hasWartAnnotation(u)(t) =>
+          case ClassDef(mods, _, _, _) if mods.hasFlag(CASE) && !mods.hasFlag(FINAL) =>
+            u.error(tree.pos, "case classes must be final")
+          // Do not look inside other classes.
+          // See: https://groups.google.com/forum/#!msg/scala-internals/vw8Kek4zlZ8/LAeakfeR3RoJ
+          case ClassDef(_, _, _, _) =>
+          case t => super.traverse(tree)
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/scala/wartremover/warts/FinalCaseClassTest.scala
+++ b/core/src/test/scala/wartremover/warts/FinalCaseClassTest.scala
@@ -1,0 +1,47 @@
+package org.brianmckenna.wartremover
+package test
+
+import org.scalatest.FunSuite
+
+import org.brianmckenna.wartremover.warts.FinalCaseClass
+
+class FinalCaseClassTest extends FunSuite {
+  test("can't declare nonfinal case classes") {
+    val result = WartTestTraverser(FinalCaseClass) {
+      case class Foo(i: Int)
+    }
+    assertResult(List("case classes must be final"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("can declare final case classes") {
+    val result = WartTestTraverser(FinalCaseClass) {
+      final case class Foo(i: Int)
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("can declare nonfinal regular classes") {
+    val result = WartTestTraverser(FinalCaseClass) {
+      class Foo(i: Int)
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("can declare nonfinal case classes inside other classes") {
+    val result = WartTestTraverser(FinalCaseClass) {
+      class Outer {
+        case class Foo(i: Int)
+      }
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("FinalCaseClass wart obeys SuppressWarnings") {
+    val result = WartTestTraverser(FinalCaseClass) {
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.FinalCaseClass"))
+      case class Foo(i: Int)
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+}


### PR DESCRIPTION
This Pull Request introduces a new Wart that enforces `final`ity for `case class`es. See https://github.com/puffnfresh/wartremover/issues/136 for more details.