### PR TITLE
Eliminate try/catch in hasWartAnnotation.

### DIFF
--- a/core/src/main/scala/wartremover/WartTraverser.scala
+++ b/core/src/main/scala/wartremover/WartTraverser.scala
@@ -69,8 +69,14 @@ trait WartTraverser {
       }
   }
 
-	def hasWartAnnotation(u: WartUniverse)(t: u.universe.Tree) =
-		Try(t.symbol.annotations.exists(isWartAnnotation(u))).getOrElse(false)
+  def hasWartAnnotation(u: WartUniverse)(tree: u.universe.Tree) = {
+    import u.universe._
+    tree match {
+      case t: ValOrDefDef => t.symbol.annotations.exists(isWartAnnotation(u))
+      case t: ImplDef => t.symbol.annotations.exists(isWartAnnotation(u))
+      case t => false
+    }
+  }
 }
 
 object WartTraverser {

--- a/core/src/main/scala/wartremover/warts/Return.scala
+++ b/core/src/main/scala/wartremover/warts/Return.scala
@@ -11,9 +11,8 @@ object Return extends WartTraverser {
           case t if hasWartAnnotation(u)(t) =>
           case u.universe.Return(_) =>
             u.error(tree.pos, "return is disabled")
-          case _ =>
+          case _ => super.traverse(tree)
         }
-        super.traverse(tree)
       }
     }
   }


### PR DESCRIPTION
@puffnfresh This PR is intended to address https://github.com/puffnfresh/wartremover/issues/164. I don't have a big project to test this against at the moment but running Wartremover on my TBox project with `allBut(Wart.Any, Wart.Nothing, Wart.NonUnitStatements, Wart.AsInstanceOf)` I saw big improvements in the speed of `hasWartAnnoation`.

### Before
![haswartannotationbefore1](https://cloud.githubusercontent.com/assets/1002726/7524546/ce16cc0c-f4d0-11e4-81a0-59fa897fa2ad.png)
### After
![haswartannotationafter1](https://cloud.githubusercontent.com/assets/1002726/7524557/d3d4bfd2-f4d0-11e4-82f0-ca98445b1ecc.png)
