### PR TITLE
Add a wart that errors on implicit conversion from option to iterable.

### DIFF
--- a/core/src/main/scala/wartremover/warts/Option2Iterable.scala
+++ b/core/src/main/scala/wartremover/warts/Option2Iterable.scala
@@ -24,4 +24,3 @@ object Option2Iterable extends WartTraverser {
     }
   }
 }
-// Select(Select(This(TypeName("scala")), scala.Option), TermName("option2Iterable"))

--- a/core/src/main/scala/wartremover/warts/Option2Iterable.scala
+++ b/core/src/main/scala/wartremover/warts/Option2Iterable.scala
@@ -1,0 +1,22 @@
+package org.brianmckenna.wartremover
+package warts
+
+object Option2Iterable extends WartTraverser {
+  def apply(u: WartUniverse): u.Traverser = {
+    import u.universe._
+
+    new u.Traverser {
+      override def traverse(tree: Tree): Unit = {
+        tree match {
+          // Ignore trees marked by SuppressWarnings
+          case t if hasWartAnnotation(u)(t) =>
+          case Select(Select(This(TypeName("scala")), TermName("Option")), TermName("option2Iterable")) =>
+            u.error(tree.pos, "Implicit conversion from Option to Iterable is disabled - use Option#toIterable instead")
+          case _ =>
+            super.traverse(tree)
+        }
+      }
+    }
+  }
+}
+// Select(Select(This(TypeName("scala")), scala.Option), TermName("option2Iterable"))

--- a/core/src/main/scala/wartremover/warts/Option2Iterable.scala
+++ b/core/src/main/scala/wartremover/warts/Option2Iterable.scala
@@ -5,12 +5,17 @@ object Option2Iterable extends WartTraverser {
   def apply(u: WartUniverse): u.Traverser = {
     import u.universe._
 
+    val scala = newTypeName("scala")
+    val option = newTermName("Option")
+    val option2Iterable = newTermName("option2Iterable")
+
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {
           // Ignore trees marked by SuppressWarnings
           case t if hasWartAnnotation(u)(t) =>
-          case Select(Select(This(TypeName("scala")), TermName("Option")), TermName("option2Iterable")) =>
+          case Select(Select(This(pkg), obj), method)
+            if pkg == scala && obj == option && method == option2Iterable =>
             u.error(tree.pos, "Implicit conversion from Option to Iterable is disabled - use Option#toIterable instead")
           case _ =>
             super.traverse(tree)

--- a/core/src/test/scala/wartremover/warts/Option2IterableTest.scala
+++ b/core/src/test/scala/wartremover/warts/Option2IterableTest.scala
@@ -1,0 +1,49 @@
+package org.brianmckenna.wartremover
+package test
+
+import org.scalatest.FunSuite
+
+import org.brianmckenna.wartremover.warts.Option2Iterable
+
+class Option2IterableTest extends FunSuite {
+
+  test("can't use Option.option2Iterable with Some") {
+    val result = WartTestTraverser(Option2Iterable) {
+      println(Iterable(1).flatMap(Some(_)))
+    }
+    assertResult(List("Implicit conversion from Option to Iterable is disabled - use Option#toIterable instead"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("can't use Option.option2Iterable with None") {
+    val result = WartTestTraverser(Option2Iterable) {
+      println(Iterable(1).flatMap(_ => None))
+    }
+    assertResult(List("Implicit conversion from Option to Iterable is disabled - use Option#toIterable instead"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("can't use Option.option2Iterable when zipping Options") {
+    val result = WartTestTraverser(Option2Iterable) {
+      println(Option(1) zip Option(2))
+    }
+    assertResult(List("Implicit conversion from Option to Iterable is disabled - use Option#toIterable instead", "Implicit conversion from Option to Iterable is disabled - use Option#toIterable instead"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("doesn't detect user defined option2Iterable functions") {
+    def option2Iterable[A](o: Option[A]): Iterable[A] = o.toIterable
+    val result = WartTestTraverser(Option2Iterable) {
+      println(option2Iterable(Some(1)))
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("Option2Iterable wart obeys SuppressWarnings") {
+    val result = WartTestTraverser(Option2Iterable) {
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Option2Iterable"))
+      val foo = {
+        println(Iterable(1).flatMap(Some(_)))
+      }
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+}


### PR DESCRIPTION
@puffnfresh This PR creates a new `Option2Iterable` wart that disables the implicit conversion from `Option` to `Iterable` as per https://github.com/puffnfresh/wartremover/issues/2