### PR TITLE
Add a wart to forbid scala's Enumeration trait.

### DIFF
--- a/core/src/main/scala/wartremover/warts/Enumeration.scala
+++ b/core/src/main/scala/wartremover/warts/Enumeration.scala
@@ -1,0 +1,22 @@
+package org.brianmckenna.wartremover
+package warts
+
+object Enumeration extends WartTraverser {
+  def apply(u: WartUniverse): u.Traverser = {
+    import u.universe._
+
+    val enumeration = typeOf[scala.Enumeration].typeSymbol
+
+    new u.Traverser {
+      override def traverse(tree: Tree): Unit = {
+        tree match {
+          // Ignore trees marked by SuppressWarnings
+          case t if hasWartAnnotation(u)(t) =>
+          case t: ImplDef if t.symbol.typeSignature.baseClasses.contains(enumeration) =>
+            u.error(tree.pos, "Enumeration is disabled - use case objects instead")
+          case t => super.traverse(tree)
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/scala/wartremover/warts/EnumerationTest.scala
+++ b/core/src/test/scala/wartremover/warts/EnumerationTest.scala
@@ -1,0 +1,48 @@
+package org.brianmckenna.wartremover
+package test
+
+import org.scalatest.FunSuite
+
+import org.brianmckenna.wartremover.warts.{ Enumeration => EnumerationWart }
+
+class EnumerationTest extends FunSuite {
+  test("can't declare Enumeration classes") {
+    val result = WartTestTraverser(EnumerationWart) {
+      class Color extends Enumeration {
+        val Red = Value
+        val Blue = Value
+      }
+    }
+    assertResult(List("Enumeration is disabled - use case objects instead"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("can't declare Enumeration objects") {
+    val result = WartTestTraverser(EnumerationWart) {
+      object Color extends Enumeration {
+        val Red = Value
+        val Blue = Value
+      }
+    }
+    assertResult(List("Enumeration is disabled - use case objects instead"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("can use user-defined Enumeration traits") {
+    val result = WartTestTraverser(EnumerationWart) {
+      trait Enumeration
+      object Foo extends Enumeration
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("Enumeration wart obeys SuppressWarnings") {
+    val result = WartTestTraverser(EnumerationWart) {
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Enumeration"))
+      object Color extends Enumeration {
+        val Red = Value
+        val Blue = Value
+      }
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+}


### PR DESCRIPTION
@puffnfresh This PR adds a wart which disables `scala.Enumeration` as per https://github.com/puffnfresh/wartremover/issues/100.

The error message recommends using `case object`s instead. Let me know if this is acceptable.