### PR TITLE
Ignore null in the synthetic methods created for default arguments.

### DIFF
--- a/core/src/main/scala/wartremover/warts/Null.scala
+++ b/core/src/main/scala/wartremover/warts/Null.scala
@@ -20,7 +20,7 @@ object Null extends WartTraverser {
           case t if hasWartAnnotation(u)(t) =>
           // Ignore xml literals
           case Apply(Select(left, _), _) if xmlSymbols.contains(left.tpe.typeSymbol.fullName) =>
-          // Ignore synthetic case class's companion object unapply
+          // Ignore synthetic methods in companion objects
           case ModuleDef(mods, _, Template(parents, self, stats)) =>
             mods.annotations foreach { annotation =>
               traverse(annotation)
@@ -30,7 +30,7 @@ object Null extends WartTraverser {
             }
             traverse(self)
             stats filter {
-              case dd@DefDef(_, UnapplyName | UnapplySeqName, _, _, _, _) if isSynthetic(u)(dd) =>
+              case dd: DefDef if isSynthetic(u)(dd) =>
                 false
               case _ =>
                 true

--- a/core/src/test/scala/wartremover/warts/NullTest.scala
+++ b/core/src/test/scala/wartremover/warts/NullTest.scala
@@ -21,6 +21,14 @@ class NullTest extends FunSuite {
     assertResult(List("null is disabled"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
+  test("can't use null in default arguments") {
+    val result = WartTestTraverser(Null) {
+      class ClassWithArgs(val foo: String = null)
+      case class CaseClassWithArgs(val foo: String = null)
+    }
+    assertResult(List("null is disabled", "null is disabled"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
   test("can't use null inside of Map#partition") {
     val result = WartTestTraverser(Null) {
       Map(1 -> "one", 2 -> "two").partition { case (k, v) => null.asInstanceOf[Boolean] }
@@ -37,6 +45,16 @@ class NullTest extends FunSuite {
         println(a)
         Map(1 -> "one", 2 -> "two").partition { case (k, v) => null.asInstanceOf[Boolean] }
       }
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("Null wart obeys SuppressWarnings in classes with default arguments") {
+    val result = WartTestTraverser(Null) {
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Null"))
+      class ClassWithArgs(val foo: String = null)
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Null"))
+      case class CaseClassWithArgs(val foo: String = null)
     }
     assertResult(List.empty, "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)


### PR DESCRIPTION
@puffnfresh This PR fixes the issue noted in https://github.com/puffnfresh/wartremover/issues/171. The `Null` wart previously ignored synthetic `unapply` methods in companion objects, it now ignores *all* synthetic methods in companion objects which includes the synthetic methods created for default arguments.