### PR TITLE
Add a wart that disables implicits without a type ascription.

### DIFF
--- a/core/src/main/scala/wartremover/warts/ExplicitImplicitTypes.scala
+++ b/core/src/main/scala/wartremover/warts/ExplicitImplicitTypes.scala
@@ -9,7 +9,7 @@ object ExplicitImplicitTypes extends WartTraverser {
     import u.universe.Flag._
 
     def hasTypeAscription(tree: ValOrDefDef) : Boolean = 
-      new Regex("""(val|def)\w*""" + tree.name.decoded.toString.trim + """\w*:""")
+      new Regex("""(val|def)\s*""" + tree.name.decoded.toString.trim + """\s*:""")
         .findFirstIn(tree.pos.lineContent).nonEmpty
 
     new u.Traverser {

--- a/core/src/main/scala/wartremover/warts/ExplicitImplicitTypes.scala
+++ b/core/src/main/scala/wartremover/warts/ExplicitImplicitTypes.scala
@@ -17,7 +17,7 @@ object ExplicitImplicitTypes extends WartTraverser {
         tree match {
           // Ignore trees marked by SuppressWarnings
           case t if hasWartAnnotation(u)(t) =>
-          case t: ValOrDefDef if t.mods.hasFlag(IMPLICIT) && !isSynthetic(u)(t) && !hasTypeAscription(t) =>
+          case t: ValOrDefDef if t.mods.hasFlag(IMPLICIT) && !t.mods.hasFlag(PARAM) && !isSynthetic(u)(t) && !hasTypeAscription(t) =>
             u.error(tree.pos, "implicit definitions must have an explicit type ascription")
           case t => super.traverse(tree)
         }

--- a/core/src/main/scala/wartremover/warts/ExplicitImplicitTypes.scala
+++ b/core/src/main/scala/wartremover/warts/ExplicitImplicitTypes.scala
@@ -1,0 +1,27 @@
+package org.brianmckenna.wartremover
+package warts
+
+import scala.util.matching.Regex
+
+object ExplicitImplicitTypes extends WartTraverser {
+  def apply(u: WartUniverse): u.Traverser = {
+    import u.universe._
+    import u.universe.Flag._
+
+    def hasTypeAscription(tree: ValOrDefDef) : Boolean = 
+      new Regex("""(val|def)\w*""" + tree.name.decoded.toString.trim + """\w*:""")
+        .findFirstIn(tree.pos.lineContent).nonEmpty
+
+    new u.Traverser {
+      override def traverse(tree: Tree): Unit = {
+        tree match {
+          // Ignore trees marked by SuppressWarnings
+          case t if hasWartAnnotation(u)(t) =>
+          case t: ValOrDefDef if t.mods.hasFlag(IMPLICIT) && !isSynthetic(u)(t) && !hasTypeAscription(t) =>
+            u.error(tree.pos, "implicit definitions must have an explicit type ascription")
+          case t => super.traverse(tree)
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/scala/wartremover/warts/ExplicitImplicitTypes.scala
+++ b/core/src/test/scala/wartremover/warts/ExplicitImplicitTypes.scala
@@ -1,0 +1,57 @@
+package org.brianmckenna.wartremover
+package test
+
+import org.scalatest.FunSuite
+
+import org.brianmckenna.wartremover.warts.ExplicitImplicitTypes
+
+class ExplicitImplicitTypesTest extends FunSuite {
+  test("can't declare implicit vals without a type ascription") {
+    val result = WartTestTraverser(ExplicitImplicitTypes) {
+      implicit val foo = 5
+    }
+    assertResult(List("implicit definitions must have an explicit type ascription"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("can't declare implicit defs without a type ascription") {
+    val result = WartTestTraverser(ExplicitImplicitTypes) {
+      implicit def foo = 5
+    }
+    assertResult(List("implicit definitions must have an explicit type ascription"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("can declare implicit classes") {
+    val result = WartTestTraverser(ExplicitImplicitTypes) {
+      implicit class Foo(i : Int) {
+        def bar = 2
+      }
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("can declare non-implicit vals") {
+    val result = WartTestTraverser(ExplicitImplicitTypes) {
+      val foo = 5
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("can declare non-implicit defs") {
+    val result = WartTestTraverser(ExplicitImplicitTypes) {
+      def foo = 5
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("ExplicitImplicitTypes wart obeys SuppressWarnings") {
+    val result = WartTestTraverser(ExplicitImplicitTypes) {
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.ExplicitImplicitTypes"))
+      implicit val foo = 5
+
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.ExplicitImplicitTypes"))
+      implicit def bar = 5
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+}

--- a/core/src/test/scala/wartremover/warts/ExplicitImplicitTypes.scala
+++ b/core/src/test/scala/wartremover/warts/ExplicitImplicitTypes.scala
@@ -29,6 +29,15 @@ class ExplicitImplicitTypesTest extends FunSuite {
     assertResult(List.empty, "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
+  test("can declare implicit parameters") {
+    val result = WartTestTraverser(ExplicitImplicitTypes) {
+      Option(1).map { implicit i =>
+        i
+      }
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
   test("can declare non-implicit vals") {
     val result = WartTestTraverser(ExplicitImplicitTypes) {
       val foo = 5


### PR DESCRIPTION
@puffnfresh This PR adds a wart that disables implicit definitions without an explicit type ascription.