### PR TITLE
Add a wart to prevent usage of automatic toString.

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,12 @@ val any = List((1, 2, 3), (1, 2))
 
 `throw` implies partiality. Encode exceptions/errors as return
 values instead using `Either`. 
+
+### ToString
+
+Scala creates a `toString` method automatically for all classes. Since `toString` is based on the class name, any rename can potentially introduce bugs. This is especially pernicious for `case object`s. `toString` should be explicitly overridden wherever used.
+```scala
+case object Foo { override val toString = "Foo" }
 ```
 
 ### TryPartial

--- a/core/src/main/scala/wartremover/warts/ToString.scala
+++ b/core/src/main/scala/wartremover/warts/ToString.scala
@@ -1,0 +1,44 @@
+package org.brianmckenna.wartremover
+package warts
+
+import reflect.NameTransformer
+
+object ToString extends WartTraverser {
+  def apply(u: WartUniverse): u.Traverser = {
+    import u.universe._
+
+    val ToString: TermName = NameTransformer.encode("toString")
+
+    def notOverridden(t: Type): Boolean = {
+      val toString = t.member(ToString)
+      !(t =:= typeOf[Boolean]) &&
+        !(t =:= typeOf[Byte]) &&
+        !(t =:= typeOf[Char]) &&
+        !(t =:= typeOf[Double]) &&
+        !(t =:= typeOf[Float]) &&
+        !(t =:= typeOf[Int]) &&
+        !(t =:= typeOf[Long]) &&
+        !(t =:= typeOf[Short]) &&
+        !(t =:= typeOf[String]) &&
+        (toString.fullName == "scala.Any.toString" ||
+          toString.fullName == "scala.AnyRef.toString" ||
+          toString.fullName == "java.lang.Object.toString" ||
+          toString.isSynthetic)
+    }
+
+    new Traverser {
+      override def traverse(tree: Tree) {
+        tree match {
+          // Ignore trees marked by SuppressWarnings
+          case t if hasWartAnnotation(u)(t) =>
+
+          case Apply(Select(lhs, ToString), _) if notOverridden(lhs.tpe) =>
+            u.error(tree.pos, s"${lhs.tpe} does not override toString and automatic toString is disabled")
+
+          case _ => super.traverse(tree)
+
+        }          
+      }
+    }
+  }
+}

--- a/core/src/test/scala/wartremover/warts/ToStringTest.scala
+++ b/core/src/test/scala/wartremover/warts/ToStringTest.scala
@@ -1,0 +1,66 @@
+package org.brianmckenna.wartremover
+package test
+
+import org.scalatest.FunSuite
+
+import org.brianmckenna.wartremover.warts.ToString
+
+class ToStringTest extends FunSuite {
+  test("can't use automatic toString method") {
+    val result = WartTestTraverser(ToString) {
+      class Foo(i: Int)
+      val foo: Foo = new Foo(5)
+		foo.toString
+    }
+    assertResult(List("foo.type does not override toString and automatic toString is disabled"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("can't use automatic toString method of TypeRefs") {
+    val result = WartTestTraverser(ToString) {
+      def foo[A](a: A): String = a.toString
+    }
+    assertResult(List("a.type does not override toString and automatic toString is disabled"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("can't use generated toString method of case classes") {
+    val result = WartTestTraverser(ToString) {
+      case class Foo(i: Int)
+		Foo(5).toString
+    }
+    assertResult(List("Foo does not override toString and automatic toString is disabled"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("can't use generated toString method of case objects") {
+    val result = WartTestTraverser(ToString) {
+      case object Foo
+		Foo.toString
+    }
+    assertResult(List("Foo.type does not override toString and automatic toString is disabled"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("can use overridden toString method") {
+    val result = WartTestTraverser(ToString) {
+      case class Foo(i: Int) {
+        override val toString = s"Foo($i)"
+      }
+      class Bar(i: Int) {
+        override val toString = s"Bar($i)"
+      }
+      case object Baz { override val toString = "Baz" }
+      Foo(5).toString
+      (new Bar(5)).toString
+      Baz.toString
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("ToString wart obeys SuppressWarnings") {
+    val result = WartTestTraverser(ToString) {
+      case class Foo(i: Int)
+      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.ToString"))
+		val i = Foo(5).toString
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+} 


### PR DESCRIPTION
@puffnfresh This PR adds a wart that prevents usage of automatically generated `toString` methods as per https://github.com/puffnfresh/wartremover/issues/157. `toString` is still allowed for primitives (via whitelist).