### PR TITLE
Add TryPartial to unsafe warts list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ Checks for the following warts:
 * Return
 * Serializable
 * Throw
+* TryPartial
 * Var
 
 ### Var


### PR DESCRIPTION
As far as I understand from https://github.com/puffnfresh/wartremover/blob/v0.13/core/src/main/scala/wartremover/warts/Unsafe.scala `TryPartial` is part of the unsafe warts list.