### PR TITLE
Switch the groupid from org.brianmckenna.wartremover to org.wartremover

### DIFF
--- a/OTHER-WAYS.md
+++ b/OTHER-WAYS.md
@@ -14,7 +14,7 @@ Compile the command-line tool via `sbt core/assembly` and then use the provided 
     
       ...
     
-    $ ./wartremover -traverser org.brianmckenna.wartremover.warts.Unsafe core/src/main/scala/wartremover/Plugin.scala
+    $ ./wartremover -traverser org.wartremover.warts.Unsafe core/src/main/scala/wartremover/Plugin.scala
     core/src/main/scala/wartremover/Plugin.scala:15: error: var is disabled
       private[this] var traversers: List[WartTraverser] = List.empty
                         ^
@@ -28,13 +28,13 @@ resolvers += Resolver.sonatypeRepo("releases")
 
 addCompilerPlugin("org.brianmckenna" %% "wartremover" % "0.10")
 
-scalacOptions += "-P:wartremover:traverser:org.brianmckenna.wartremover.warts.Unsafe"
+scalacOptions += "-P:wartremover:traverser:org.wartremover.warts.Unsafe"
 ```
 
 By default, WartRemover generates compile-time errors. If you want to be warned only, use an `only-warn-traverser`:
 
 ```scala
-scalacOptions += "-P:wartremover:only-warn-traverser:org.brianmckenna.wartremover.warts.Unsafe"
+scalacOptions += "-P:wartremover:only-warn-traverser:org.wartremover.warts.Unsafe"
 ```
 
 If you don't want to perform the checks in some file, you can use:
@@ -58,8 +58,8 @@ You can make any wart into a macro, like so:
     scala> import language.experimental.macros
     import language.experimental.macros
 
-    scala> import org.brianmckenna.wartremover.warts.Unsafe
-    import org.brianmckenna.wartremover.warts.Unsafe
+    scala> import org.wartremover.warts.Unsafe
+    import org.wartremover.warts.Unsafe
 
     scala> def safe(expr: Any) = macro Unsafe.asMacro
     safe: (expr: Any)Any

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ wartremoverExcluded += baseDirectory.value / "src" / "main" / "scala" / "SomeFil
 
 To exclude a specific piece of code from one or more checks, use the `SuppressWarnings` annotation:
 ```scala
-@SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Var", "org.brianmckenna.wartremover.warts.Null"))
+@SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.Null"))
 var foo = null
 ```
 
@@ -74,7 +74,7 @@ See also [other ways of using WartRemover](/OTHER-WAYS.md) for information on ho
 ## Warts
 
 Here is a list of built-in warts under the
-`org.brianmckenna.wartremover.warts` package.
+`org.wartremover.warts` package.
 
 ### Any
 
@@ -407,7 +407,7 @@ Most traversers will want a `super.traverse` call to be able to
 recursively continue.
 
 ```scala
-import org.brianmckenna.wartremover.{WartTraverser, WartUniverse}
+import org.wartremover.{WartTraverser, WartUniverse}
 
 object Unimplemented extends WartTraverser {
   def apply(u: WartUniverse): u.Traverser = {

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import ReleaseTransformations._
 import com.typesafe.sbt.pgp.PgpKeys._
 
 lazy val commonSettings = Seq(
-  organization := "org.brianmckenna",
+  organization := "org.wartremover",
   licenses := Seq(
     "The Apache Software License, Version 2.0" ->
       url("http://www.apache.org/licenses/LICENSE-2.0.txt")
@@ -102,9 +102,9 @@ lazy val sbtPlug: Project = Project(
          |  private[wartremover] val PluginVersion = "${version.value}"
          |  private[wartremover] lazy val AllWarts = List(${warts mkString ", "})
          |  private[wartremover] lazy val UnsafeWarts = List(${unsafe mkString ", "})
-         |  /** A fully-qualified class name of a custom Wart implementing `org.brianmckenna.wartremover.WartTraverser`. */
+         |  /** A fully-qualified class name of a custom Wart implementing `org.wartremover.WartTraverser`. */
          |  def custom(clazz: String): Wart = new Wart(clazz)
-         |  private[this] def w(nm: String): Wart = new Wart(s"org.brianmckenna.wartremover.warts.$$nm")
+         |  private[this] def w(nm: String): Wart = new Wart(s"org.wartremover.warts.$$nm")
          |""".stripMargin +
         warts.map(w => s"""  val $w = w("${w}")""").mkString("\n") + "\n}\n"
     IO.write(file, content)

--- a/core/src/main/resources/scalac-plugin.xml
+++ b/core/src/main/resources/scalac-plugin.xml
@@ -1,4 +1,4 @@
 <plugin>
   <name>wartremover</name>
-  <classname>org.brianmckenna.wartremover.Plugin</classname>
+  <classname>org.wartremover.Plugin</classname>
 </plugin>

--- a/core/src/main/scala/wartremover/Main.scala
+++ b/core/src/main/scala/wartremover/Main.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 
 import tools.nsc.{Global, Settings}
 import tools.nsc.io.VirtualDirectory

--- a/core/src/main/scala/wartremover/Plugin.scala
+++ b/core/src/main/scala/wartremover/Plugin.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 
 import tools.nsc.plugins.PluginComponent
 import tools.nsc.{Global, Phase}

--- a/core/src/main/scala/wartremover/WartTraverser.scala
+++ b/core/src/main/scala/wartremover/WartTraverser.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 
 import tools.nsc.Global
 import reflect.api.Universe

--- a/core/src/main/scala/wartremover/test/TestMacro.scala
+++ b/core/src/main/scala/wartremover/test/TestMacro.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import language.experimental.macros

--- a/core/src/main/scala/wartremover/warts/Any.scala
+++ b/core/src/main/scala/wartremover/warts/Any.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object Any extends ForbidInference[Any] {

--- a/core/src/main/scala/wartremover/warts/Any2StringAdd.scala
+++ b/core/src/main/scala/wartremover/warts/Any2StringAdd.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object Any2StringAdd extends WartTraverser {

--- a/core/src/main/scala/wartremover/warts/AsInstanceOf.scala
+++ b/core/src/main/scala/wartremover/warts/AsInstanceOf.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object AsInstanceOf extends WartTraverser {

--- a/core/src/main/scala/wartremover/warts/DefaultArguments.scala
+++ b/core/src/main/scala/wartremover/warts/DefaultArguments.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object DefaultArguments extends WartTraverser {

--- a/core/src/main/scala/wartremover/warts/EitherProjectionPartial.scala
+++ b/core/src/main/scala/wartremover/warts/EitherProjectionPartial.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object EitherProjectionPartial extends WartTraverser {

--- a/core/src/main/scala/wartremover/warts/Enumeration.scala
+++ b/core/src/main/scala/wartremover/warts/Enumeration.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object Enumeration extends WartTraverser {

--- a/core/src/main/scala/wartremover/warts/ExplicitImplicitTypes.scala
+++ b/core/src/main/scala/wartremover/warts/ExplicitImplicitTypes.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 import scala.util.matching.Regex

--- a/core/src/main/scala/wartremover/warts/FinalCaseClass.scala
+++ b/core/src/main/scala/wartremover/warts/FinalCaseClass.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object FinalCaseClass extends WartTraverser {

--- a/core/src/main/scala/wartremover/warts/ForbidInference.scala
+++ b/core/src/main/scala/wartremover/warts/ForbidInference.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 trait ForbidInference[T] extends WartTraverser {

--- a/core/src/main/scala/wartremover/warts/ImplicitConversion.scala
+++ b/core/src/main/scala/wartremover/warts/ImplicitConversion.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object ImplicitConversion extends WartTraverser {

--- a/core/src/main/scala/wartremover/warts/IsInstanceOf.scala
+++ b/core/src/main/scala/wartremover/warts/IsInstanceOf.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object IsInstanceOf extends WartTraverser {

--- a/core/src/main/scala/wartremover/warts/JavaConversions.scala
+++ b/core/src/main/scala/wartremover/warts/JavaConversions.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object JavaConversions extends WartTraverser {

--- a/core/src/main/scala/wartremover/warts/LeakingSealed.scala
+++ b/core/src/main/scala/wartremover/warts/LeakingSealed.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object LeakingSealed extends WartTraverser {

--- a/core/src/main/scala/wartremover/warts/ListOps.scala
+++ b/core/src/main/scala/wartremover/warts/ListOps.scala
@@ -1,10 +1,10 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object ListOps extends WartTraverser {
 
   class Op(name: String, error: String) extends WartTraverser {
-    override lazy val className = "org.brianmckenna.wartremover.warts.ListOps"
+    override lazy val className = "org.wartremover.warts.ListOps"
 
     def apply(u: WartUniverse): u.Traverser = {
       import u.universe._

--- a/core/src/main/scala/wartremover/warts/MutableDataStructures.scala
+++ b/core/src/main/scala/wartremover/warts/MutableDataStructures.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object MutableDataStructures extends WartTraverser {

--- a/core/src/main/scala/wartremover/warts/NoNeedForMonad.scala
+++ b/core/src/main/scala/wartremover/warts/NoNeedForMonad.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object NoNeedForMonad extends WartTraverser {

--- a/core/src/main/scala/wartremover/warts/NonUnitStatements.scala
+++ b/core/src/main/scala/wartremover/warts/NonUnitStatements.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 import scala.annotation.tailrec

--- a/core/src/main/scala/wartremover/warts/Nothing.scala
+++ b/core/src/main/scala/wartremover/warts/Nothing.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object Nothing extends ForbidInference[Nothing] {

--- a/core/src/main/scala/wartremover/warts/Null.scala
+++ b/core/src/main/scala/wartremover/warts/Null.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object Null extends WartTraverser {

--- a/core/src/main/scala/wartremover/warts/Option2Iterable.scala
+++ b/core/src/main/scala/wartremover/warts/Option2Iterable.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object Option2Iterable extends WartTraverser {

--- a/core/src/main/scala/wartremover/warts/OptionPartial.scala
+++ b/core/src/main/scala/wartremover/warts/OptionPartial.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object OptionPartial extends WartTraverser {

--- a/core/src/main/scala/wartremover/warts/Overloading.scala
+++ b/core/src/main/scala/wartremover/warts/Overloading.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object Overloading extends WartTraverser {

--- a/core/src/main/scala/wartremover/warts/Product.scala
+++ b/core/src/main/scala/wartremover/warts/Product.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object Product extends ForbidInference[Product] {

--- a/core/src/main/scala/wartremover/warts/Return.scala
+++ b/core/src/main/scala/wartremover/warts/Return.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object Return extends WartTraverser {

--- a/core/src/main/scala/wartremover/warts/Serializable.scala
+++ b/core/src/main/scala/wartremover/warts/Serializable.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object Serializable extends ForbidInference[Serializable] {

--- a/core/src/main/scala/wartremover/warts/Throw.scala
+++ b/core/src/main/scala/wartremover/warts/Throw.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object Throw extends WartTraverser {

--- a/core/src/main/scala/wartremover/warts/ToString.scala
+++ b/core/src/main/scala/wartremover/warts/ToString.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 import reflect.NameTransformer

--- a/core/src/main/scala/wartremover/warts/TryPartial.scala
+++ b/core/src/main/scala/wartremover/warts/TryPartial.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object TryPartial extends WartTraverser {

--- a/core/src/main/scala/wartremover/warts/Unsafe.scala
+++ b/core/src/main/scala/wartremover/warts/Unsafe.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object Unsafe extends WartTraverser {

--- a/core/src/main/scala/wartremover/warts/Var.scala
+++ b/core/src/main/scala/wartremover/warts/Var.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object Var extends WartTraverser {

--- a/core/src/main/scala/wartremover/warts/While.scala
+++ b/core/src/main/scala/wartremover/warts/While.scala
@@ -1,4 +1,4 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package warts
 
 object While extends WartTraverser {

--- a/core/src/test/scala/wartremover/safe/CaseClassTest.scala
+++ b/core/src/test/scala/wartremover/safe/CaseClassTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.Unsafe
+import org.wartremover.warts.Unsafe
 
 class CaseClassTest extends FunSuite {
   test("case classes still work") {

--- a/core/src/test/scala/wartremover/safe/CompanionTest.scala
+++ b/core/src/test/scala/wartremover/safe/CompanionTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.Unsafe
+import org.wartremover.warts.Unsafe
 
 class CompanionTest extends FunSuite {
   test("can use companion objects for case classes") {

--- a/core/src/test/scala/wartremover/safe/ExistentialTest.scala
+++ b/core/src/test/scala/wartremover/safe/ExistentialTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.Unsafe
+import org.wartremover.warts.Unsafe
 
 class ExistentialTest extends FunSuite {
   test("can use existential values") {

--- a/core/src/test/scala/wartremover/safe/PartialFunctionTest.scala
+++ b/core/src/test/scala/wartremover/safe/PartialFunctionTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.Unsafe
+import org.wartremover.warts.Unsafe
 
 class PartialFunctionTest extends FunSuite {
   test("can use partial functions") {

--- a/core/src/test/scala/wartremover/safe/XmlLiteralTest.scala
+++ b/core/src/test/scala/wartremover/safe/XmlLiteralTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.Unsafe
+import org.wartremover.warts.Unsafe
 
 class XmlLiteralTest extends FunSuite {
   test("can use xml literals") {

--- a/core/src/test/scala/wartremover/warts/Any2StringAddTest.scala
+++ b/core/src/test/scala/wartremover/warts/Any2StringAddTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.Any2StringAdd
+import org.wartremover.warts.Any2StringAdd
 
 class Any2StringAddTest extends FunSuite {
   test("disable any2stringadd") {
@@ -15,7 +15,7 @@ class Any2StringAddTest extends FunSuite {
   }
   test("any2stringadd wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Any2StringAdd) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Any2StringAdd"))
+      @SuppressWarnings(Array("org.wartremover.warts.Any2StringAdd"))
       val foo = {} + "lol"
     }
     assertResult(List.empty, "result.errors")(result.errors)

--- a/core/src/test/scala/wartremover/warts/AnyTest.scala
+++ b/core/src/test/scala/wartremover/warts/AnyTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.Any
+import org.wartremover.warts.Any
 
 class AnyTest extends FunSuite {
   test("Any can't be inferred") {
@@ -16,7 +16,7 @@ class AnyTest extends FunSuite {
   }
   test("Any wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Any) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Any"))
+      @SuppressWarnings(Array("org.wartremover.warts.Any"))
       val x = readf1("{0}")
       x
     }

--- a/core/src/test/scala/wartremover/warts/AsInstanceOfTest.scala
+++ b/core/src/test/scala/wartremover/warts/AsInstanceOfTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.AsInstanceOf
+import org.wartremover.warts.AsInstanceOf
 
 class AsInstanceOfTest extends FunSuite {
   test("asInstanceOf is disabled") {
@@ -15,7 +15,7 @@ class AsInstanceOfTest extends FunSuite {
   }
   test("asInstanceOf wart obeys SuppressWarnings") {
     val result = WartTestTraverser(AsInstanceOf) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.AsInstanceOf"))
+      @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
       val foo = "abc".asInstanceOf[String]
     }
     assertResult(List.empty, "result.errors")(result.errors)

--- a/core/src/test/scala/wartremover/warts/DefaultArgumentsTest.scala
+++ b/core/src/test/scala/wartremover/warts/DefaultArgumentsTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.DefaultArguments
+import org.wartremover.warts.DefaultArguments
 
 class DefaultArgumentsTest extends FunSuite {
   test("Default arguments can't be used") {
@@ -15,7 +15,7 @@ class DefaultArgumentsTest extends FunSuite {
   }
   test("Default arguments wart obeys SuppressWarnings") {
     val result = WartTestTraverser(DefaultArguments) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.DefaultArguments"))
+      @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
       def x(y: Int = 4) = y
     }
     assertResult(List.empty, "result.errors")(result.errors)

--- a/core/src/test/scala/wartremover/warts/EitherProjectionPartialTest.scala
+++ b/core/src/test/scala/wartremover/warts/EitherProjectionPartialTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.EitherProjectionPartial
+import org.wartremover.warts.EitherProjectionPartial
 
 class EitherProjectionPartialTest extends FunSuite {
   test("can't use LeftProjection#get on Left") {
@@ -36,7 +36,7 @@ class EitherProjectionPartialTest extends FunSuite {
   }
   test("EitherProjectionPartial wart obeys SuppressWarnings") {
     val result = WartTestTraverser(EitherProjectionPartial) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.EitherProjectionPartial"))
+      @SuppressWarnings(Array("org.wartremover.warts.EitherProjectionPartial"))
       val foo = {
         println(Left(1).left.get)
         println(Right(1).left.get)

--- a/core/src/test/scala/wartremover/warts/EnumerationTest.scala
+++ b/core/src/test/scala/wartremover/warts/EnumerationTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.{ Enumeration => EnumerationWart }
+import org.wartremover.warts.{ Enumeration => EnumerationWart }
 
 class EnumerationTest extends FunSuite {
   test("can't declare Enumeration classes") {
@@ -36,7 +36,7 @@ class EnumerationTest extends FunSuite {
   }
   test("Enumeration wart obeys SuppressWarnings") {
     val result = WartTestTraverser(EnumerationWart) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Enumeration"))
+      @SuppressWarnings(Array("org.wartremover.warts.Enumeration"))
       object Color extends Enumeration {
         val Red = Value
         val Blue = Value

--- a/core/src/test/scala/wartremover/warts/ExplicitImplicitTypesTest.scala
+++ b/core/src/test/scala/wartremover/warts/ExplicitImplicitTypesTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.ExplicitImplicitTypes
+import org.wartremover.warts.ExplicitImplicitTypes
 
 class ExplicitImplicitTypesTest extends FunSuite {
   test("can't declare implicit vals without a type ascription") {
@@ -87,10 +87,10 @@ class ExplicitImplicitTypesTest extends FunSuite {
 
   test("ExplicitImplicitTypes wart obeys SuppressWarnings") {
     val result = WartTestTraverser(ExplicitImplicitTypes) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.ExplicitImplicitTypes"))
+      @SuppressWarnings(Array("org.wartremover.warts.ExplicitImplicitTypes"))
       implicit val foo = 5
 
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.ExplicitImplicitTypes"))
+      @SuppressWarnings(Array("org.wartremover.warts.ExplicitImplicitTypes"))
       implicit def bar = 5
     }
     assertResult(List.empty, "result.errors")(result.errors)

--- a/core/src/test/scala/wartremover/warts/FinalCaseClassTest.scala
+++ b/core/src/test/scala/wartremover/warts/FinalCaseClassTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.FinalCaseClass
+import org.wartremover.warts.FinalCaseClass
 
 class FinalCaseClassTest extends FunSuite {
   test("can't declare nonfinal case classes") {
@@ -38,7 +38,7 @@ class FinalCaseClassTest extends FunSuite {
   }
   test("FinalCaseClass wart obeys SuppressWarnings") {
     val result = WartTestTraverser(FinalCaseClass) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.FinalCaseClass"))
+      @SuppressWarnings(Array("org.wartremover.warts.FinalCaseClass"))
       case class Foo(i: Int)
     }
     assertResult(List.empty, "result.errors")(result.errors)

--- a/core/src/test/scala/wartremover/warts/ImplicitConversionTest.scala
+++ b/core/src/test/scala/wartremover/warts/ImplicitConversionTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.ImplicitConversion
+import org.wartremover.warts.ImplicitConversion
 
 class ImplicitConversionTest extends FunSuite {
   test("Implicit conversion is disabled") {
@@ -29,7 +29,7 @@ class ImplicitConversionTest extends FunSuite {
   test("ImplicitConversion wart obeys SuppressWarnings") {
     val result = WartTestTraverser(ImplicitConversion) {
       class c {
-        @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.ImplicitConversion"))
+        @SuppressWarnings(Array("org.wartremover.warts.ImplicitConversion"))
         implicit def int2Array(i: Int): Array[String] = Array.fill(i)("?")
       }
     }

--- a/core/src/test/scala/wartremover/warts/IsInstanceOfTest.scala
+++ b/core/src/test/scala/wartremover/warts/IsInstanceOfTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.IsInstanceOf
+import org.wartremover.warts.IsInstanceOf
 
 class IsInstanceOfTest extends FunSuite {
   test("isInstanceOf is disabled") {
@@ -15,7 +15,7 @@ class IsInstanceOfTest extends FunSuite {
   }
   test("isInstanceOf wart obeys SuppressWarnings") {
     val result = WartTestTraverser(IsInstanceOf) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.IsInstanceOf"))
+      @SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf"))
       val foo = "abc".isInstanceOf[String]
     }
     assertResult(List.empty, "result.errors")(result.errors)

--- a/core/src/test/scala/wartremover/warts/JavaConversionsTest.scala
+++ b/core/src/test/scala/wartremover/warts/JavaConversionsTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.JavaConversions
+import org.wartremover.warts.JavaConversions
 
 class JavaConversionsTest extends FunSuite {
    test("handle explicit method reference") {
@@ -27,7 +27,7 @@ class JavaConversionsTest extends FunSuite {
   }
   test("JavaConversions wart obeys SuppressWarnings") {
     val result = WartTestTraverser(JavaConversions) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.JavaConversions"))
+      @SuppressWarnings(Array("org.wartremover.warts.JavaConversions"))
       def ff[A](it: Iterable[A]) = collection.JavaConversions.asJavaCollection(it)
     }
     assertResult(List.empty, "result.errors")(result.errors)

--- a/core/src/test/scala/wartremover/warts/LeakingSealedTest.scala
+++ b/core/src/test/scala/wartremover/warts/LeakingSealedTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.LeakingSealed
+import org.wartremover.warts.LeakingSealed
 
 class LeakingSealedTest extends FunSuite {
   test("Descendants of a sealed type must be final or sealed") {
@@ -28,7 +28,7 @@ class LeakingSealedTest extends FunSuite {
   test("LeakingSealed wart obeys SuppressWarnings") {
     val result = WartTestTraverser(LeakingSealed) {
       sealed trait t
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.LeakingSealed"))
+      @SuppressWarnings(Array("org.wartremover.warts.LeakingSealed"))
       class c extends t
     }
     assertResult(List.empty, "result.errors")(result.errors)

--- a/core/src/test/scala/wartremover/warts/ListTest.scala
+++ b/core/src/test/scala/wartremover/warts/ListTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.ListOps
+import org.wartremover.warts.ListOps
 
 class ListTest extends FunSuite {
   test("can't use List#head on List") {
@@ -64,7 +64,7 @@ class ListTest extends FunSuite {
 
   test("ListOps wart obeys SuppressWarnings") {
     val result = WartTestTraverser(ListOps) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.ListOps"))
+      @SuppressWarnings(Array("org.wartremover.warts.ListOps"))
       val foo = {
         println(List(1).head)
         println(List().tail)

--- a/core/src/test/scala/wartremover/warts/MutableDataStructuresTest.scala
+++ b/core/src/test/scala/wartremover/warts/MutableDataStructuresTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.MutableDataStructures
+import org.wartremover.warts.MutableDataStructures
 
 class MutableDataStructuresTest extends FunSuite {
   test("disable scala.collection.mutable._ when referenced") {
@@ -22,7 +22,7 @@ class MutableDataStructuresTest extends FunSuite {
   }
   test("MutableDataStructures wart obeys SuppressWarnings") {
     val result = WartTestTraverser(MutableDataStructures) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.MutableDataStructures"))
+      @SuppressWarnings(Array("org.wartremover.warts.MutableDataStructures"))
       var x = scala.collection.mutable.HashMap("key" -> "value")
     }
     assertResult(List.empty, "result.errors")(result.errors)

--- a/core/src/test/scala/wartremover/warts/NoNeedForMonadTest.scala
+++ b/core/src/test/scala/wartremover/warts/NoNeedForMonadTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.NoNeedForMonad
+import org.wartremover.warts.NoNeedForMonad
 
 class NoNeedForMonadTest extends FunSuite {
   test("Report cases where Applicative is enough") {
@@ -83,7 +83,7 @@ class NoNeedForMonadTest extends FunSuite {
 
   test("NoNeedForMonad wart obeys SuppressWarnings") {
     val result = WartTestTraverser(NoNeedForMonad) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.NoNeedForMonad"))
+      @SuppressWarnings(Array("org.wartremover.warts.NoNeedForMonad"))
       val foo = {
         for {
           x <- List(1, 2, 3)

--- a/core/src/test/scala/wartremover/warts/NonUnitStatementsTest.scala
+++ b/core/src/test/scala/wartremover/warts/NonUnitStatementsTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.NonUnitStatements
+import org.wartremover.warts.NonUnitStatements
 
 class NonUnitStatementsTest extends FunSuite {
   test("non-unit statements are disabled") {
@@ -32,7 +32,7 @@ class NonUnitStatementsTest extends FunSuite {
   }
   test("NonUnitStatements wart obeys SuppressWarnings") {
     val result = WartTestTraverser(NonUnitStatements) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.NonUnitStatements"))
+      @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
       val foo = {
         1
         2

--- a/core/src/test/scala/wartremover/warts/NothingTest.scala
+++ b/core/src/test/scala/wartremover/warts/NothingTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.Nothing
+import org.wartremover.warts.Nothing
 
 class NothingTest extends FunSuite {
   test("Nothing can't be inferred") {
@@ -16,7 +16,7 @@ class NothingTest extends FunSuite {
   }
   test("Nothing wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Nothing) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Nothing"))
+      @SuppressWarnings(Array("org.wartremover.warts.Nothing"))
       val x = ???
       x
     }

--- a/core/src/test/scala/wartremover/warts/NullTest.scala
+++ b/core/src/test/scala/wartremover/warts/NullTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.Null
+import org.wartremover.warts.Null
 
 class NullTest extends FunSuite {
   test("can't use `null`") {
@@ -38,7 +38,7 @@ class NullTest extends FunSuite {
   }
   test("Null wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Null) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Null"))
+      @SuppressWarnings(Array("org.wartremover.warts.Null"))
       val foo = {
         println(null)
         val (a, b) = (1, null)
@@ -51,9 +51,9 @@ class NullTest extends FunSuite {
   }
   test("Null wart obeys SuppressWarnings in classes with default arguments") {
     val result = WartTestTraverser(Null) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Null"))
+      @SuppressWarnings(Array("org.wartremover.warts.Null"))
       class ClassWithArgs(val foo: String = null)
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Null"))
+      @SuppressWarnings(Array("org.wartremover.warts.Null"))
       case class CaseClassWithArgs(val foo: String = null)
     }
     assertResult(List.empty, "result.errors")(result.errors)

--- a/core/src/test/scala/wartremover/warts/Option2IterableTest.scala
+++ b/core/src/test/scala/wartremover/warts/Option2IterableTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.Option2Iterable
+import org.wartremover.warts.Option2Iterable
 
 class Option2IterableTest extends FunSuite {
 
@@ -38,7 +38,7 @@ class Option2IterableTest extends FunSuite {
   }
   test("Option2Iterable wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Option2Iterable) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Option2Iterable"))
+      @SuppressWarnings(Array("org.wartremover.warts.Option2Iterable"))
       val foo = {
         println(Iterable(1).flatMap(Some(_)))
       }

--- a/core/src/test/scala/wartremover/warts/OptionPartialTest.scala
+++ b/core/src/test/scala/wartremover/warts/OptionPartialTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.OptionPartial
+import org.wartremover.warts.OptionPartial
 
 class OptionPartialTest extends FunSuite {
   test("can't use Option#get on Some") {
@@ -30,7 +30,7 @@ class OptionPartialTest extends FunSuite {
   }
   test("OptionPartial wart obeys SuppressWarnings") {
     val result = WartTestTraverser(OptionPartial) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.OptionPartial"))
+      @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
       val foo = {
         println(Some(1).get)
         println(None.get)

--- a/core/src/test/scala/wartremover/warts/OverloadingTest.scala
+++ b/core/src/test/scala/wartremover/warts/OverloadingTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.Overloading
+import org.wartremover.warts.Overloading
 
 class OverloadingTest extends FunSuite {
   test("Overloading is disabled") {
@@ -20,7 +20,7 @@ class OverloadingTest extends FunSuite {
 
   test("Overloading wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Overloading) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Overloading"))
+      @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
       class c {
         def f(i: Int) = {}
         def f(s: String) = {}
@@ -35,7 +35,7 @@ class OverloadingTest extends FunSuite {
     val result = WartTestTraverser(Overloading) {
       class c {
         def f(i: Int) = {}
-        @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Overloading"))
+        @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
         def f(s: String) = {}
       }
     }

--- a/core/src/test/scala/wartremover/warts/ProductTest.scala
+++ b/core/src/test/scala/wartremover/warts/ProductTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.Product
+import org.wartremover.warts.Product
 
 class ProductTest extends FunSuite {
   test("Product can't be inferred") {
@@ -15,7 +15,7 @@ class ProductTest extends FunSuite {
   }
   test("Product wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Product) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Product"))
+      @SuppressWarnings(Array("org.wartremover.warts.Product"))
       val foo = List((1, 2, 3), (1, 2))
     }
     assertResult(List.empty, "result.errors")(result.errors)

--- a/core/src/test/scala/wartremover/warts/ReturnTest.scala
+++ b/core/src/test/scala/wartremover/warts/ReturnTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.Return
+import org.wartremover.warts.Return
 
 class ReturnTest extends FunSuite {
   test("local return is disabled") {
@@ -22,9 +22,9 @@ class ReturnTest extends FunSuite {
   }
   test("Return wart is disabled") {
     val result = WartTestTraverser(Return) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Return"))
+      @SuppressWarnings(Array("org.wartremover.warts.Return"))
       def foo(n:Int): Int = return n + 1
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Return"))
+      @SuppressWarnings(Array("org.wartremover.warts.Return"))
       def bar(ns: List[Int]): Any = ns.map(n => return n + 1)
     }
     assertResult(List.empty, "result.errors")(result.errors)

--- a/core/src/test/scala/wartremover/warts/SerializableTest.scala
+++ b/core/src/test/scala/wartremover/warts/SerializableTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.Serializable
+import org.wartremover.warts.Serializable
 
 class SerializableTest extends FunSuite {
   test("Serializable can't be inferred") {
@@ -15,7 +15,7 @@ class SerializableTest extends FunSuite {
   }
   test("Serializable wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Serializable) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Serializable"))
+      @SuppressWarnings(Array("org.wartremover.warts.Serializable"))
       val foo = List((1, 2, 3), (1, 2))
     }
     assertResult(List.empty, "result.errors")(result.errors)

--- a/core/src/test/scala/wartremover/warts/ThrowTest.scala
+++ b/core/src/test/scala/wartremover/warts/ThrowTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.Throw
+import org.wartremover.warts.Throw
 
 class ThrowTest extends FunSuite {
   test("throw is disabled") {
@@ -32,7 +32,7 @@ class ThrowTest extends FunSuite {
 
   test("Throw wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Throw) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Throw"))
+      @SuppressWarnings(Array("org.wartremover.warts.Throw"))
       def foo(n: Int): Int = throw new IllegalArgumentException("bar")
     }
     assertResult(List.empty, "result.errors")(result.errors)

--- a/core/src/test/scala/wartremover/warts/ToStringTest.scala
+++ b/core/src/test/scala/wartremover/warts/ToStringTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.ToString
+import org.wartremover.warts.ToString
 
 class ToStringTest extends FunSuite {
   test("can't use automatic toString method") {
@@ -70,7 +70,7 @@ class ToStringTest extends FunSuite {
   test("ToString wart obeys SuppressWarnings") {
     val result = WartTestTraverser(ToString) {
       case class Foo(i: Int)
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.ToString"))
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       val i = Foo(5).toString
     }
     assertResult(List.empty, "result.errors")(result.errors)

--- a/core/src/test/scala/wartremover/warts/TryPartialTest.scala
+++ b/core/src/test/scala/wartremover/warts/TryPartialTest.scala
@@ -1,8 +1,8 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
-import org.brianmckenna.wartremover.warts.TryPartial
+import org.wartremover.warts.TryPartial
 import scala.util.{Try, Success, Failure}
 
 class TryPartialTest extends FunSuite {
@@ -30,7 +30,7 @@ class TryPartialTest extends FunSuite {
   }
   test("TryPartial wart obeys SuppressWarnings") {
     val result = WartTestTraverser(TryPartial) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.TryPartial"))
+      @SuppressWarnings(Array("org.wartremover.warts.TryPartial"))
       val foo = {
         println(Success(1).get)
         println(Failure(new Error).get)

--- a/core/src/test/scala/wartremover/warts/UnsafeTest.scala
+++ b/core/src/test/scala/wartremover/warts/UnsafeTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.Unsafe
+import org.wartremover.warts.Unsafe
 
 class UnsafeTest extends FunSuite {
   test("can't use `null`, `var`, non-unit statements, Option#get, LeftProjection#get, RightProjection#get, or any2stringadd") {

--- a/core/src/test/scala/wartremover/warts/VarTest.scala
+++ b/core/src/test/scala/wartremover/warts/VarTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.Var
+import org.wartremover.warts.Var
 
 class VarTest extends FunSuite {
   test("can't use `var`") {
@@ -16,7 +16,7 @@ class VarTest extends FunSuite {
   }
   test("Var wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Var) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Var"))
+      @SuppressWarnings(Array("org.wartremover.warts.Var"))
       var x = 10
       x
     }

--- a/core/src/test/scala/wartremover/warts/WhileTest.scala
+++ b/core/src/test/scala/wartremover/warts/WhileTest.scala
@@ -1,9 +1,9 @@
-package org.brianmckenna.wartremover
+package org.wartremover
 package test
 
 import org.scalatest.FunSuite
 
-import org.brianmckenna.wartremover.warts.While
+import org.wartremover.warts.While
 
 class WhileTest extends FunSuite {
   test("while is disabled") {
@@ -28,7 +28,7 @@ class WhileTest extends FunSuite {
 
   test("while wart obeys SuppressWarnings") {
     val result = WartTestTraverser(While) {
-      @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.While"))
+      @SuppressWarnings(Array("org.wartremover.warts.While"))
       def f() = {
         while (true) {
         }


### PR DESCRIPTION
As the title says, this PR switches the groupid and all package paths to the use `org.wartremover`. This is the one big breaking change that needs to be made before the 1.0.0 release.