### PR TITLE
ExplicitImplicitTypes should handle backticks.

### DIFF
--- a/core/src/main/scala/wartremover/warts/ExplicitImplicitTypes.scala
+++ b/core/src/main/scala/wartremover/warts/ExplicitImplicitTypes.scala
@@ -9,7 +9,7 @@ object ExplicitImplicitTypes extends WartTraverser {
     import u.universe.Flag._
 
     def hasTypeAscription(tree: ValOrDefDef) : Boolean =
-      new Regex("""(val|var|def)\s*""" + tree.name.decodedName.toString.trim + """(\[.*\])?(\(.*\))*\s*:""")
+      new Regex("""(val|var|def)\s*`?""" + tree.name.decodedName.toString.trim + """`?(\[.*\])?(\(.*\))*\s*:""")
         .findFirstIn(tree.pos.lineContent).nonEmpty
 
     new u.Traverser {

--- a/core/src/test/scala/wartremover/warts/ExplicitImplicitTypesTest.scala
+++ b/core/src/test/scala/wartremover/warts/ExplicitImplicitTypesTest.scala
@@ -85,6 +85,16 @@ class ExplicitImplicitTypesTest extends FunSuite {
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
 
+  test("can declare backticked implicit defs") {
+    val result = WartTestTraverser(ExplicitImplicitTypes) {
+      implicit def `foo`: Int = 5
+      implicit val `foobar`: String = "5"
+      implicit def `foo bar`: Long = 5L
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+
   test("ExplicitImplicitTypes wart obeys SuppressWarnings") {
     val result = WartTestTraverser(ExplicitImplicitTypes) {
       @SuppressWarnings(Array("org.wartremover.warts.ExplicitImplicitTypes"))


### PR DESCRIPTION
This PR resolves https://github.com/puffnfresh/wartremover/issues/236.