### PR TITLE
Switched wartremoverExcluded to a task key

### DIFF
--- a/sbt-plugin/src/main/scala/wartremover/package.scala
+++ b/sbt-plugin/src/main/scala/wartremover/package.scala
@@ -5,7 +5,7 @@ import Keys._
 package object wartremover {
   val wartremoverErrors = settingKey[Seq[Wart]]("List of Warts that will be reported as compilation errors.")
   val wartremoverWarnings = settingKey[Seq[Wart]]("List of Warts that will be reported as compilation warnings.")
-  val wartremoverExcluded = settingKey[Seq[File]]("List of files to be excluded from all checks.")
+  val wartremoverExcluded = taskKey[Seq[File]]("List of files to be excluded from all checks.")
   val wartremoverClasspaths = settingKey[Seq[String]]("List of classpaths for custom Warts")
 
   lazy val wartremoverSettings: Seq[sbt.Def.Setting[_]] = Seq(


### PR DESCRIPTION
Hi,
this is just a suggestion, but I found it useful to let the excluded option depending on other tasks. In my case I wanted to exclude all files generated by the play routes source generator.