### PR TITLE
Switched wartremoverClasspaths to a task key

### DIFF
--- a/sbt-plugin/src/main/scala/wartremover/package.scala
+++ b/sbt-plugin/src/main/scala/wartremover/package.scala
@@ -6,7 +6,7 @@ package object wartremover {
   val wartremoverErrors = settingKey[Seq[Wart]]("List of Warts that will be reported as compilation errors.")
   val wartremoverWarnings = settingKey[Seq[Wart]]("List of Warts that will be reported as compilation warnings.")
   val wartremoverExcluded = taskKey[Seq[File]]("List of files to be excluded from all checks.")
-  val wartremoverClasspaths = settingKey[Seq[String]]("List of classpaths for custom Warts")
+  val wartremoverClasspaths = taskKey[Seq[String]]("List of classpaths for custom Warts")
 
   lazy val wartremoverSettings: Seq[sbt.Def.Setting[_]] = Seq(
     wartremoverErrors := Seq.empty,


### PR DESCRIPTION
Hi again,
this is quite similar to my last PR. With this change ```wartremoverClasspaths``` can depend on ```update```, which makes it easy to use the dependency resolution mechanisms of sbt to pull appropriate jars.  

In Play Warts exsits an workaround for this, but it fails if you use something other than IVY (e.g. coursier) [See PlayWarts.scala](https://github.com/danielnixon/playwarts/blob/master/sbt-plugin/src/main/scala/org/danielnixon/playwarts/PlayWarts.scala#L25)