### PR TITLE
The Null wart should also forbid Option#orNull

### DIFF
--- a/core/src/test/scala/wartremover/warts/NullTest.scala
+++ b/core/src/test/scala/wartremover/warts/NullTest.scala
@@ -36,11 +36,19 @@ class NullTest extends FunSuite {
     assertResult(List("null is disabled"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
+  test("can't use `Option#orNull`") {
+    val result = WartTestTraverser(Null) {
+      println(None.orNull)
+    }
+    assertResult(List("Option#orNull is disabled"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
   test("Null wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Null) {
       @SuppressWarnings(Array("org.wartremover.warts.Null"))
       val foo = {
         println(null)
+        println(None.orNull)
         val (a, b) = (1, null)
         println(a)
         Map(1 -> "one", 2 -> "two").partition { case (k, v) => null.asInstanceOf[Boolean] }


### PR DESCRIPTION
This PR completes https://github.com/puffnfresh/wartremover/issues/251 by adding a check for `Option#orNull` to the `Null` wart.