### PR TITLE
fix #159 MatchError bug

### DIFF
--- a/core/src/main/scala/wartremover/warts/NoNeedForMonad.scala
+++ b/core/src/main/scala/wartremover/warts/NoNeedForMonad.scala
@@ -11,13 +11,16 @@ object NoNeedForMonad extends WartTraverser {
     import u.universe._
 
     def processForComprehension(tree: Tree, enums: List[Tree], body: Tree): Unit = {
-      val bindings = enums.flatMap { case fq"$lhs <- $rhs" =>
-        lhs match {
-          case Bind(name, _) => List((Ident(name): Tree, rhs))
-          case Apply(_, bindings: List[Tree]) => bindings.map {
-            case Bind(name, _) => (Ident(name): Tree, rhs)
+      val bindings = enums.flatMap {
+        case fq"$lhs <- $rhs" =>
+          lhs match {
+            case Bind(name, _) => List((Ident(name): Tree, rhs))
+            case Apply(_, bindings: List[Tree]) => bindings.map {
+              case Bind(name, _) => (Ident(name): Tree, rhs)
+            }
           }
-        }
+        case _ =>
+          Nil
       }.toMap
 
       val names = bindings.keys

--- a/core/src/test/scala/wartremover/warts/NoNeedForMonadTest.scala
+++ b/core/src/test/scala/wartremover/warts/NoNeedForMonadTest.scala
@@ -108,4 +108,13 @@ class NoNeedForMonadTest extends FunSuite {
     assertResult(List.empty, "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
+
+  test("should not cause MatchError") {
+    WartTestTraverser(NoNeedForMonad) {
+      for {
+        a <- List(1)
+        b = a
+      } yield b
+    }
+  }
 }


### PR DESCRIPTION
```
core/src/test/scala/wartremover/warts/NoNeedForMonadTest.scala:113: exception during macro expansion:
[error] scala.MatchError: (b @ _) = a (of class scala.reflect.internal.Trees$Assign)
[error]         at org.wartremover.warts.NoNeedForMonad$$anonfun$1.apply(NoNeedForMonad.scala:14)
[error]         at org.wartremover.warts.NoNeedForMonad$$anonfun$1.apply(NoNeedForMonad.scala:14)
[error]         at scala.collection.immutable.List.flatMap(List.scala:327)
[error]         at org.wartremover.warts.NoNeedForMonad$.org$wartremover$warts$NoNeedForMonad$$processForComprehension$1(NoNeedForMonad.scala:14)
[error]         at org.wartremover.warts.NoNeedForMonad$$anon$1.traverse(NoNeedForMonad.scala:82)
[error]         at org.wartremover.test.WartTestTraverser$.applyImpl(TestMacro.scala:25)
[error]     WartTestTraverser(NoNeedForMonad) {
[error]                                       ^
[error] one error found
[error] (core/test:compileIncremental) Compilation failed
```