### PR TITLE
Better handling of if in for comprehensions for NoNeedForMonad

### DIFF
--- a/core/src/main/scala/wartremover/warts/NoNeedForMonad.scala
+++ b/core/src/main/scala/wartremover/warts/NoNeedForMonad.scala
@@ -11,14 +11,19 @@ object NoNeedForMonad extends WartTraverser {
     import u.universe._
 
     def processForComprehension(tree: Tree, enums: List[Tree], body: Tree): Unit = {
-      val bindings = enums.flatMap { case fq"$lhs <- $rhs" =>
-        lhs match {
-          case Bind(name, _) => List((Ident(name): Tree, rhs))
-          case Apply(_, bindings: List[Tree]) => bindings.map {
-            case Bind(name, _) => (Ident(name): Tree, rhs)
-          }
-        }
-      }.toMap
+      val bindings =
+        enums.flatMap {
+          case fq"$lhs <- $rhs" =>
+            lhs match {
+              case Bind(name, _) =>
+                List((Ident(name): Tree, rhs))
+              case Apply(_, bindings: List[Tree]) =>
+                bindings.map {
+                  case Bind(name, _) => (Ident(name): Tree, rhs)
+                }
+            }
+          case _ => Nil
+        }.toMap
 
       val names = bindings.keys
       val rhss  = bindings.values

--- a/core/src/test/scala/wartremover/warts/NoNeedForMonadTest.scala
+++ b/core/src/test/scala/wartremover/warts/NoNeedForMonadTest.scala
@@ -108,4 +108,17 @@ class NoNeedForMonadTest extends FunSuite {
     assertResult(List.empty, "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
+
+  test("Handles if") {
+    val result = WartTestTraverser(NoNeedForMonad) {
+      for {
+        i1 <- Option(1)
+        i2 <- Option(1)
+        if i1 == 1
+      } yield i1
+    }
+
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List(NoNeedForMonad.message), "result.warnings")(result.warnings)
+  }
 }


### PR DESCRIPTION
I just updated the macro so it no longer crashes on the input given in the test. 

Should we update the wart detection logic while we're at it? i suppose a value referenced in such a conditional would express a dependency?
