### PR TITLE
Fix Any2StringAdd doesn't handle "primitive + string", "string + any"

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,11 @@ Scala has an implicit that converts anything to a `String` if the
 right hand side of `+` is a `String`.
 
 ```scala
-// Won't compile: Scala inserted an any2stringadd call
+// Won't compile: Implicit conversion to string is disabled
 println({} + "test")
 ```
+
+Reverse case (`string + any`) is also disabled.
 
 ### AsInstanceOf
 

--- a/core/src/main/scala/wartremover/warts/Any2StringAdd.scala
+++ b/core/src/main/scala/wartremover/warts/Any2StringAdd.scala
@@ -5,19 +5,27 @@ object Any2StringAdd extends WartTraverser {
   def apply(u: WartUniverse): u.Traverser = {
     import u.universe._
 
-    val PredefName: TermName = "Predef"
-    val Any2StringAddName: TermName = "any2stringadd"
+    val Plus: TermName = "$plus"
+
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {
           // Ignore trees marked by SuppressWarnings
           case t if hasWartAnnotation(u)(t) =>
-          case Apply(Select(Select(_, PredefName), Any2StringAddName), _) =>
-            u.error(tree.pos, "Scala inserted an any2stringadd call")
+
+          case Apply(Select(lhs, Plus), List(rhs))
+            if (lhs.tpe <:< typeOf[String] ^ rhs.tpe <:< typeOf[String]) && !isSynthetic(u)(tree) =>
+            val overriddenPlus = lhs.symbol != null && lhs.symbol.owner != null && {
+              val owner = lhs.symbol.owner
+              owner.isClass && !owner.isSynthetic && owner.typeSignature.members.exists { x =>
+                x.isMethod && x.name.toTermName == Plus && !x.annotations.exists(isWartAnnotation(u))
+              }
+            }
+            if (!overriddenPlus) {
+              u.error(tree.pos, "Implicit conversion to string is disabled")
+            }
             super.traverse(tree)
-          case TypeApply(Select(Select(_, PredefName), Any2StringAddName), _) =>
-            u.error(tree.pos, "Scala inserted an any2stringadd call")
-            super.traverse(tree)
+
           case _ => super.traverse(tree)
         }
       }

--- a/core/src/test/scala/wartremover/warts/Any2StringAddTest.scala
+++ b/core/src/test/scala/wartremover/warts/Any2StringAddTest.scala
@@ -6,13 +6,27 @@ import org.scalatest.FunSuite
 import org.wartremover.warts.Any2StringAdd
 
 class Any2StringAddTest extends FunSuite {
-  test("disable any2stringadd") {
+  test("Implicit conversion to string is disabled") {
     val result = WartTestTraverser(Any2StringAdd) {
       {} + "lol"
+      1 + "lol"
+      "lol" + 1
     }
-    assertResult(List("Scala inserted an any2stringadd call"), "result.errors")(result.errors)
+    assertResult(List.fill(3)("Implicit conversion to string is disabled"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
+
+  test("other plus usages are allowed") {
+    val result = WartTestTraverser(Any2StringAdd) {
+      1 + 1
+      "a" + "b"
+      class C { def +(s: String) = s }
+      new C + "a"
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+
   test("any2stringadd wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Any2StringAdd) {
       @SuppressWarnings(Array("org.wartremover.warts.Any2StringAdd"))

--- a/core/src/test/scala/wartremover/warts/UnsafeTest.scala
+++ b/core/src/test/scala/wartremover/warts/UnsafeTest.scala
@@ -20,7 +20,7 @@ class UnsafeTest extends FunSuite {
     assertResult(
       Set("Inferred type containing Any",
            "Inferred type containing Any",
-           "Scala inserted an any2stringadd call",
+           "Implicit conversion to string is disabled",
            "LeftProjection#get is disabled - use LeftProjection#toOption instead",
            "RightProjection#get is disabled - use RightProjection#toOption instead",
            "LeftProjection#get is disabled - use LeftProjection#toOption instead",


### PR DESCRIPTION
Should it allow `+`'ing string literals?

`abc + ""` - here the code shows that someone actually wanted to make a string.
