### PR TITLE
Update LeakingSealed and test harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,15 +199,15 @@ val javaMap: java.util.Map[String, String] = scalaMap
 
 ### LeakingSealed
 
-Descendants of a sealed type must be final or sealed. Otherwise this type can be extended in another file through its descendant.
+`sealed` modifier restricts inheritance only for direct descendants. This rule disables indirect inheritance as well.
 
 ```scala
 file 1:
-// Won't compile: Descendants of a sealed type must be final or sealed
 sealed trait t
 class c extends t
 
 file 2:
+// Won't compile: Descendants of a sealed parent must be located in the parent's file
 class d extends c
 ```
 

--- a/core/src/main/scala/wartremover/Main.scala
+++ b/core/src/main/scala/wartremover/Main.scala
@@ -2,6 +2,7 @@ package org.wartremover
 
 import tools.nsc.{Global, Settings}
 import tools.nsc.io.VirtualDirectory
+import tools.nsc.reporters.{ConsoleReporter, Reporter}
 
 object Main {
   case class WartArgs(traversers: List[String], names: List[String]) {
@@ -19,14 +20,14 @@ object Main {
     case Nil => processed
   }
 
-  def compile(args: WartArgs) = {
+  def compile(args: WartArgs, reporter: Option[Reporter] = None) = {
     val settings = new Settings()
     val virtualDirectory = new VirtualDirectory("(memory)", None)
     settings.outputDirs.setSingleOutput(virtualDirectory)
-    settings.usejavacp.value = true
+    settings.embeddedDefaults(getClass.getClassLoader)
     settings.pluginOptions.value = args.traversers.map("wartremover:traverser:" ++ _)
 
-    val global = new Global(settings) {
+    val global = new Global(settings, reporter.getOrElse(new ConsoleReporter(settings))) {
       override protected def loadRoughPluginsList() = List(new Plugin(this))
     }
     val run = new global.Run()

--- a/core/src/main/scala/wartremover/warts/LeakingSealed.scala
+++ b/core/src/main/scala/wartremover/warts/LeakingSealed.scala
@@ -4,7 +4,6 @@ package warts
 object LeakingSealed extends WartTraverser {
   def apply(u: WartUniverse): u.Traverser = {
     import u.universe._
-    import u.universe.Flag._
 
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
@@ -12,8 +11,10 @@ object LeakingSealed extends WartTraverser {
           // Ignore trees marked by SuppressWarnings
           case t if hasWartAnnotation(u)(t) =>
           case t @ ClassDef(mods, _, _, _)
-            if !mods.hasFlag(FINAL) && !mods.hasFlag(SEALED) && t.symbol.asClass.baseClasses.exists(_.asClass.isSealed) =>
-            u.error(tree.pos, "Descendants of a sealed type must be final or sealed")
+            if t.symbol.asClass.baseClasses.exists { parent =>
+              parent.asClass.isSealed && parent.associatedFile != t.symbol.associatedFile
+            } =>
+              u.error(tree.pos, "Descendants of a sealed parent must be located in the parent's file")
             super.traverse(tree)
           case _ =>
             super.traverse(tree)

--- a/core/src/test/resources/LeakingSealed/A.scala
+++ b/core/src/test/resources/LeakingSealed/A.scala
@@ -1,0 +1,2 @@
+sealed trait A
+class A1 extends A

--- a/core/src/test/resources/LeakingSealed/B.scala
+++ b/core/src/test/resources/LeakingSealed/B.scala
@@ -1,0 +1,1 @@
+class B extends A1

--- a/core/src/test/resources/LeakingSealed/C.scala
+++ b/core/src/test/resources/LeakingSealed/C.scala
@@ -1,0 +1,2 @@
+@SuppressWarnings(Array("org.wartremover.warts.LeakingSealed"))
+class C extends A1

--- a/core/src/test/scala/wartremover/warts/LeakingSealedTest.scala
+++ b/core/src/test/scala/wartremover/warts/LeakingSealedTest.scala
@@ -2,35 +2,19 @@ package org.wartremover
 package test
 
 import org.scalatest.FunSuite
-
 import org.wartremover.warts.LeakingSealed
 
 class LeakingSealedTest extends FunSuite {
-  test("Descendants of a sealed type must be final or sealed") {
-    val result = WartTestTraverser(LeakingSealed) {
-      sealed trait t
-      class c extends t
-    }
-    assertResult(List("Descendants of a sealed type must be final or sealed"), "result.errors")(result.errors)
-    assertResult(List.empty, "result.warnings")(result.warnings)
-  }
+  test("Descendants of a sealed parent must be located in the parent's file") {
+    val result = WartTestTraverser.applyToFiles(LeakingSealed)(List("LeakingSealed/A.scala", "LeakingSealed/B.scala"))
 
-  test("Final or sealed descendants of a sealed type are allowed") {
-    val result = WartTestTraverser(LeakingSealed) {
-      sealed trait t
-      final class c extends t
-      sealed trait tt extends t
-    }
-    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List("Descendants of a sealed parent must be located in the parent's file"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
 
   test("LeakingSealed wart obeys SuppressWarnings") {
-    val result = WartTestTraverser(LeakingSealed) {
-      sealed trait t
-      @SuppressWarnings(Array("org.wartremover.warts.LeakingSealed"))
-      class c extends t
-    }
+    val result = WartTestTraverser.applyToFiles(LeakingSealed)(List("LeakingSealed/A.scala", "LeakingSealed/C.scala"))
+
     assertResult(List.empty, "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }


### PR DESCRIPTION
New LeakingSealed triggers, if a user actually tries to extend a sealed type in another file, and doesn't impose additional modifiers.

Also tests can now run traversers on sample files.
