### PR TITLE
New rule: SomeApply

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,31 @@ Scala's `String` interface provides a `+` method that converts the operand to a 
 {} + "bar"
 ```
 
+### SomeApply
+
+`Some.apply` may break typing in two ways: First, when it is used with a null value, creating an instance of `Some(null)` instead of the (usually) expected `None`, and; Second, when it causes type inference to infer `Some[T]` instead of the (usually) expected `Option[T]`. Use `Option.apply` instead, to cover both cases.
+
+```scala
+def someOfNull(foo: String) = {
+  // Won't compile: Some.apply is disabled - use Option.apply instead
+  val expectedSafeFoo: Option[String] = Some(foo) // If foo == null, Some(null)
+  val actualSafeFoo: Option[String] = Option(foo) // If foo == null, None
+}
+```
+
+```scala
+def typeInference() = {
+  // Won't compile: Some.apply is disabled - use Option.apply instead
+  val maybeFoo = Some("bar") // maybeFoo has type Some[String], not Option[String]...
+  
+  // ...so the following code would not have compiled
+  maybeFoo match {
+    case Some(value) => // ...
+    case None => // ...
+  }
+}
+```
+
 ### Throw
 
 `throw` implies partiality. Encode exceptions/errors as return
@@ -403,6 +428,7 @@ Checks for the following warts:
 * Product
 * Return
 * Serializable
+* SomeApply
 * Throw
 * TryPartial
 * Var

--- a/core/src/main/scala/wartremover/warts/SomeApply.scala
+++ b/core/src/main/scala/wartremover/warts/SomeApply.scala
@@ -18,7 +18,6 @@ object SomeApply extends WartTraverser {
             if pkg == scala && obj == some && method == app =>
             u.error(tree.pos, "Some.apply is disabled - use Option.apply instead")
           case v =>
-            println(v)
             super.traverse(tree)
         }
       }

--- a/core/src/main/scala/wartremover/warts/SomeApply.scala
+++ b/core/src/main/scala/wartremover/warts/SomeApply.scala
@@ -1,0 +1,22 @@
+package org.wartremover
+package warts
+
+object SomeApply extends WartTraverser {
+  def apply(u: WartUniverse): u.Traverser = {
+    import u.universe._
+
+    new u.Traverser {
+      override def traverse(tree: Tree): Unit = {
+        tree match {
+          // Ignore trees marked by SuppressWarnings
+          case t if hasWartAnnotation(u)(t) =>
+          case Apply(TypeApply(Select(Select(Ident(TermName("scala")), TermName("Some")), TermName("apply")), _), _) =>
+            u.error(tree.pos, "Some.apply is disabled - use Option.apply instead")
+          case v =>
+            println(v)
+            super.traverse(tree)
+        }
+      }
+    }
+  }
+}

--- a/core/src/main/scala/wartremover/warts/SomeApply.scala
+++ b/core/src/main/scala/wartremover/warts/SomeApply.scala
@@ -5,12 +5,17 @@ object SomeApply extends WartTraverser {
   def apply(u: WartUniverse): u.Traverser = {
     import u.universe._
 
+    val scala: TermName = "scala"
+    val some: TermName = "Some"
+    val app: TermName = "apply"
+
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         tree match {
           // Ignore trees marked by SuppressWarnings
           case t if hasWartAnnotation(u)(t) =>
-          case Apply(TypeApply(Select(Select(Ident(TermName("scala")), TermName("Some")), TermName("apply")), _), _) =>
+          case Apply(TypeApply(Select(Select(Ident(pkg), obj), method), _), _)
+            if pkg == scala && obj == some && method == app =>
             u.error(tree.pos, "Some.apply is disabled - use Option.apply instead")
           case v =>
             println(v)

--- a/core/src/main/scala/wartremover/warts/Unsafe.scala
+++ b/core/src/main/scala/wartremover/warts/Unsafe.scala
@@ -16,6 +16,7 @@ object Unsafe extends WartTraverser {
     Product,
     Return,
     Serializable,
+    SomeApply,
     Throw,
     TryPartial,
     Var

--- a/core/src/test/scala/wartremover/warts/SomeApplyTest.scala
+++ b/core/src/test/scala/wartremover/warts/SomeApplyTest.scala
@@ -1,0 +1,37 @@
+package org.wartremover
+package test
+
+import org.scalatest.FunSuite
+import org.wartremover.warts.SomeApply
+
+class SomeApplyTest extends FunSuite with ResultAssertions {
+
+  test("can't use Some.apply with null") {
+    val result = WartTestTraverser(SomeApply) {
+      Some(null)
+    }
+    assertError(result)("Some.apply is disabled - use Option.apply instead")
+  }
+  test("can't use Some.apply with a literal") {
+    val result = WartTestTraverser(SomeApply) {
+      Some(1)
+    }
+    assertError(result)("Some.apply is disabled - use Option.apply instead")
+  }
+  test("can't use Some.apply with an identifier") {
+    val result = WartTestTraverser(SomeApply) {
+      val x = 1
+      Some(x)
+    }
+    assertError(result)("Some.apply is disabled - use Option.apply instead")
+  }
+  test("can use Some.unapply in pattern matching") {
+    val result = WartTestTraverser(SomeApply) {
+      Option("test") match {
+        case Some(test) => println(test)
+        case None => println("not gonna happen")
+      }
+    }
+    assertEmpty(result)
+  }
+}

--- a/core/src/test/scala/wartremover/warts/UnsafeTest.scala
+++ b/core/src/test/scala/wartremover/warts/UnsafeTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.FunSuite
 import org.wartremover.warts.Unsafe
 
 class UnsafeTest extends FunSuite {
-  test("can't use `null`, `var`, non-unit statements, Option#get, LeftProjection#get, RightProjection#get, or any2stringadd") {
+  test("can't use `null`, `var`, non-unit statements, Option#get, LeftProjection#get, RightProjection#get, any2stringadd, or Some.apply") {
     val result = WartTestTraverser(Unsafe) {
       val x = List(1, true, "three")
       var u = {} + "Hello!"
@@ -28,7 +28,8 @@ class UnsafeTest extends FunSuite {
            "Statements must return Unit",
            "null is disabled",
            "Option#get is disabled - use Option#fold instead",
-           "var is disabled"), "result.errors")(result.errors.toSet)
+           "var is disabled",
+           "Some.apply is disabled - use Option.apply instead"), "result.errors")(result.errors.toSet)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
 }


### PR DESCRIPTION
`Some.apply` may break typing in two ways: First, when it is used with a null value, creating an instance of `Some(null)` instead of the (usually) expected `None`, and; Second, when it causes type inference to infer `Some[T]` instead of the (usually) expected `Option[T]`. Use `Option.apply` instead, to cover both cases.

```scala
def someOfNull(foo: String) = {
  // Won't compile: Some.apply is disabled - use Option.apply instead
  val expectedSafeFoo: Option[String] = Some(foo) // If foo == null, Some(null)
  val actualSafeFoo: Option[String] = Option(foo) // If foo == null, None
}
```

```scala
def typeInference() = {
  // Won't compile: Some.apply is disabled - use Option.apply instead
  val maybeFoo = Some("bar") // maybeFoo has type Some[String], not Option[String]...
  
  // ...so the following code would not have compiled
  maybeFoo match {
    case Some(value) => // ...
    case None => // ...
  }
}
```
